### PR TITLE
Updated RunValueParser-> for float numbers, use decimal point format …

### DIFF
--- a/internal/processor/values.go
+++ b/internal/processor/values.go
@@ -56,11 +56,11 @@ func RunSubParse(subParse []load.Parse, currentSample *map[string]interface{}, k
 func RunValueParser(v *interface{}, api load.API, key *string) {
 	for regexKey, regexVal := range api.ValueParser {
 		if formatter.KvFinder("regex", *key, regexKey) {
-			var value interface{}
+			value := ""
 			switch (*v).(type) {
 			case float32, float64:
-				// For float numbers, use decimal point format instead of scientific notation for large exponents(e.g. 2026112.000000 vs 2.026112e+06 )
-				// to allow parser to process the original float number 2026112.000000 rather 2.026112e+06
+				// For float numbers, use decimal point format instead of scientific notation (e.g. 2026112.000000 vs 2.026112e+06 )
+				// to allow the parser to process the original float number 2026112.000000 rather than 2.026112e+06
 				value = fmt.Sprintf("%f", *v)
 			default:
 				value = fmt.Sprintf("%v", *v)


### PR DESCRIPTION
**Updated RunValueParser logic**

For value with data types -> float64 and float32, use decimal point format instead of scientific notation (e.g. 2026112.000000 vs 2.026112e+06 ), this is to allow the parser to process the original float number 2026112.000000 rather than 2.026112e+06.  

For other data types, the logic remains unchanged. 

**For example:** 
```
    value_parser:
      id: "[0-9]+"
```

_Before the change:_ 
`    id-> 2`

_After the change:_
`   id-> 2026112`
