### PR TITLE
Func RunKeepKeys not deleting keys

### DIFF
--- a/internal/processor/create.go
+++ b/internal/processor/create.go
@@ -79,7 +79,7 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int) {
 			VariableLookups(api.StoreVariables, &key, &config.VariableStore, &v) // store variable
 
 			// if keepkeys used will do inverse
-			RunKeepKeys(api.KeepKeys, &key, &currentSample, &k)
+			RunKeepKeys(api.KeepKeys, &key, &currentSample)
 			RunSampleRenamer(api.RenameSamples, &currentSample, key, &eventType)
 		}
 

--- a/internal/processor/keys.go
+++ b/internal/processor/keys.go
@@ -38,7 +38,7 @@ func RunKeepKeys(keepKeys []string, key *string, currentSample *map[string]inter
 			}
 		}
 		if !foundKey {
-			delete(*currentSample, *k)
+			delete(*currentSample, *key)
 		}
 	}
 }

--- a/internal/processor/keys.go
+++ b/internal/processor/keys.go
@@ -28,7 +28,7 @@ func RunKeyConversion(key *string, api load.API, v interface{}, SkipProcessing *
 }
 
 // RunKeepKeys Removes all other keys/attributes and keep only those defined in keep_keys
-func RunKeepKeys(keepKeys []string, key *string, currentSample *map[string]interface{}, k *string) {
+func RunKeepKeys(keepKeys []string, key *string, currentSample *map[string]interface{}) {
 	if len(keepKeys) > 0 {
 		foundKey := false
 		for _, keepKey := range keepKeys {

--- a/internal/processor/keys_test.go
+++ b/internal/processor/keys_test.go
@@ -66,12 +66,12 @@ func TestKeepKeys(t *testing.T) {
 		"abc":   1,
 		"xyz":   2,
 		"dfadf": "dafsdfa",
+		"def":   "initely busted",
 	}
 
 	key := "def"
-	k := "def"
 
-	RunKeepKeys(keepKeys, &key, &currentSample, &k)
+	RunKeepKeys(keepKeys, &key, &currentSample)
 	output, _ := json.Marshal(currentSample)
 	expected := `{"abc":1,"dfadf":"dafsdfa","xyz":2}`
 


### PR DESCRIPTION
During some testing today I found that the "keep_keys" option didn't appear to be working properly.  After going through various test scenarios (and code), I found that the delete() statement in "RunKeepKeys()" appears to be using the wrong variable.   After switching to *key, the statement appears to do what I expected.