### PR TITLE
Updated RunSampleRenamer - change the conflicting variable name regex…

### DIFF
--- a/internal/processor/create.go
+++ b/internal/processor/create.go
@@ -198,8 +198,8 @@ func SetEventType(currentSample *map[string]interface{}, eventType *string, apiE
 
 // RunSampleRenamer using regex if sample has a key that matches, make that a different sample (event_type)
 func RunSampleRenamer(renameSamples map[string]string, currentSample *map[string]interface{}, key string, eventType *string) {
-	for regex, newEventType := range renameSamples {
-		if formatter.KvFinder(regex, key, regex) {
+	for regexLocal, newEventType := range renameSamples {
+		if formatter.KvFinder(regex, key, regexLocal) {
 			(*currentSample)["event_type"] = newEventType
 			*eventType = newEventType
 			break


### PR DESCRIPTION
- The RunSampleRenamer is not working properly due to conflicting variable name "regex".
- Changing the local "regex" variable name to "regexLocal" to avoid overriding the same variable defined on line 26. 