### PR TITLE
[zackm] adding various linux examples

### DIFF
--- a/examples/flexConfigs/clock-drift-chrony.yml
+++ b/examples/flexConfigs/clock-drift-chrony.yml
@@ -1,0 +1,6 @@
+# Queries chronyc to return offset from current time server
+name: clockDriftChrony
+apis:
+  - name: clockDriftChrony
+    commands:
+      - run: echo -e "{\"remote\":\"$(chronyc tracking | grep "Reference ID" | awk 'match($0,/\((.*)\)/) { print substr($0,RSTART+1,RLENGTH-2)}')\",\"ntpOffset\":$(printf '%.0f\n' $(echo "$(chronyc tracking | grep "Last offset" | awk 'match($0,/(\+|\-).*(\s)/) { print substr($0,RSTART+1,RLENGTH-2)}')*1000" | bc -l))}"

--- a/examples/flexConfigs/clock-drift-ntp.yml
+++ b/examples/flexConfigs/clock-drift-ntp.yml
@@ -1,0 +1,6 @@
+# Queries ntpq to return offset from current time server
+name: clockDriftNTP
+apis:
+  - name: clockDriftNTP
+    commands:
+      - run: echo -e "{\"remote\":\"$(ntpq -np | grep "\*"  | awk '{print $1}' | tr -d '\*' | tr -d '\+')\",\"offset\":$(ntpq -np | grep "\*" | cut -c 62-66 | tr -d '-' | awk '{$1=$1};1')}"

--- a/examples/flexConfigs/linux-directory-size.yml
+++ b/examples/flexConfigs/linux-directory-size.yml
@@ -1,0 +1,10 @@
+# Used to query Directory Size via Disk Usage
+name: linuxDirectorySize
+apis:
+  - name: linuxDirectorySize
+    commands:
+      - run: du -sb /var/db/newrelic-infra/custom-integrations/
+        split: horizontal
+        set_header: [dirSizeBytes,dirName]
+        regex_match: true
+        split_by: (\d+)\s+(.*)

--- a/examples/flexConfigs/linux-file-age.yml
+++ b/examples/flexConfigs/linux-file-age.yml
@@ -1,0 +1,10 @@
+# Used to query file age via File Status
+name: linuxFileAge
+apis:
+  - name: linuxFileAge
+    commands:
+      - run: stat -c '%n;%y' /etc/*conf
+        split: horizontal
+        set_header: [fileName,fileAgeSeconds]
+        regex_match: false
+        split_by: ";"

--- a/examples/flexConfigs/linux-file-count.yml
+++ b/examples/flexConfigs/linux-file-count.yml
@@ -1,0 +1,6 @@
+# Used to file count via List
+name: linuxFileCount
+apis:
+  - name: linuxFileCount
+    commands:
+      - run: echo -e "{\"searchFilter\":\"/etc\",\"fileCount\":\"$(ls -1 /etc | wc -l)\"}"

--- a/examples/flexConfigs/linux-file-size.yml
+++ b/examples/flexConfigs/linux-file-size.yml
@@ -1,0 +1,10 @@
+# Used to query File Size via File Status
+name: linuxFileSize
+apis:
+  - name: linuxFileSize
+    commands:
+      - run: stat -c '%n;%s' /etc/*conf
+        split: horizontal
+        set_header: [fileName,fileSizeBytes]
+        regex_match: false
+        split_by: ";"

--- a/examples/flexConfigs/linux-filesystem.yml
+++ b/examples/flexConfigs/linux-filesystem.yml
@@ -1,0 +1,12 @@
+# Used to query file systems not natively supported by New Relic using Disk Free
+# ref: https://docs.newrelic.com/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-events#linux-supported
+name: linuxFilesystem
+apis:
+  - name: linuxFilesystem
+    commands:
+      - run: df -PT -B1 -x tmpfs -x xfs -x vxfs -x btrfs -x ext -x ext2 -x ext3 -x ext4 -x hfs
+        split: horizontal
+        set_header: [fs,fsType,capacityBytes,usedBytes,availableBytes,usedPerc,mountedOn]
+        regex_match: true
+        split_by: (\S+.\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)
+    perc_to_decimal: true

--- a/examples/flexConfigs/linux-processes-filtered.yml
+++ b/examples/flexConfigs/linux-processes-filtered.yml
@@ -1,0 +1,24 @@
+# Used to query Process Status, with filtering
+# This is useful to monitor processes with Command Lines > 4k characters*
+#   *current limit for the 'strip_command_line' attribute for the Infrastructure Agent
+name: linuxProcessFiltered
+apis:
+  - name: linuxProcessFiltered
+    commands:
+      - event_type: processfilterTanium
+        run: ps -eo pid,ppid,time,euser,cmd | grep -E "sshd" | grep -v grep
+        split: horizontal
+        set_header: [processID,parentID,time,userName,commandLine]
+        regex_match: true
+        split_by: (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)
+        custom_attributes:
+          processFilter: "sshd"
+      # Note you can monitor multiple processes in the single YAML configuration
+      - event_type: processfilterDhclient
+        run: ps -eo pid,ppid,time,euser,cmd | grep -E "dhclient" | grep -v grep
+        split: horizontal
+        set_header: [processID,parentID,time,userName,commandLine]
+        regex_match: true
+        split_by: (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)
+        custom_attributes:
+          processFilter: "dhclient"


### PR DESCRIPTION
adding several examples of basic configurations used in linux distros:

> examples/flexConfigs/clock-drift-chrony.yml
> examples/flexConfigs/clock-drift-ntp.yml
> examples/flexConfigs/linux-directory-size.yml
> examples/flexConfigs/linux-file-age.yml
> examples/flexConfigs/linux-file-count.yml
> examples/flexConfigs/linux-file-size.yml
> examples/flexConfigs/linux-filesystem.yml
> examples/flexConfigs/linux-processes-filtered.yml