### PR TITLE
fix yaml nesting to support multiple processes

### DIFF
--- a/examples/flexConfigs/linux-processes-filtered.yml
+++ b/examples/flexConfigs/linux-processes-filtered.yml
@@ -3,22 +3,22 @@
 #   *current limit for the 'strip_command_line' attribute for the Infrastructure Agent
 name: linuxProcessFiltered
 apis:
-  - name: linuxProcessFiltered
+  - name: processfilterSshd
     commands:
-      - event_type: processfilterTanium
-        run: ps -eo pid,ppid,time,euser,cmd | grep -E "sshd" | grep -v grep
+      - run: ps -eo pid,ppid,time,euser,cmd | grep -E "sshd" | grep -v grep
         split: horizontal
         set_header: [processID,parentID,time,userName,commandLine]
         regex_match: true
         split_by: (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)
         custom_attributes:
           processFilter: "sshd"
-      # Note you can monitor multiple processes in the single YAML configuration
-      - event_type: processfilterDhclient
-        run: ps -eo pid,ppid,time,euser,cmd | grep -E "dhclient" | grep -v grep
+  # Note you can monitor multiple processes in the single YAML configuration
+  - name: processfilterDhclient
+    commands:
+      - run: ps -eo pid,ppid,time,euser,cmd | grep -E "dhclient" | grep -v grep
         split: horizontal
         set_header: [processID,parentID,time,userName,commandLine]
         regex_match: true
         split_by: (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)
         custom_attributes:
-          processFilter: "dhclient"
+          processFilter: dhclient

--- a/examples/flexConfigs/linux-processes-filtered.yml
+++ b/examples/flexConfigs/linux-processes-filtered.yml
@@ -11,7 +11,7 @@ apis:
         regex_match: true
         split_by: (\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)
         custom_attributes:
-          processFilter: "sshd"
+          processFilter: sshd
   # Note you can monitor multiple processes in the single YAML configuration
   - name: processfilterDhclient
     commands:


### PR DESCRIPTION
updated to correct YAML nesting to support creating multiple different event types in a single config and update misnamed process and custom_attribute from `tanium` >> `sshd`