### PR TITLE
Don't forcing the config_file/config_path argument to have yml/yaml extension

### DIFF
--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -84,8 +84,12 @@ func addSingleConfigFile(configFile string, configs *[]load.Config) {
 		}).Fatal("config: failed to read")
 	}
 	path := strings.Replace(filepath.FromSlash(configFile), file.Name(), "", -1)
-	files := []os.FileInfo{file}
-	config.LoadFiles(configs, files, path)
+	if err := config.LoadFile(configs, file, path); err != nil {
+		load.Logrus.WithFields(logrus.Fields{
+			"err":  err,
+			"file": configFile,
+		}).Error("config: failed to load file")
+	}
 }
 
 func addConfigsFromPath(path string, configs *[]load.Config) {


### PR DESCRIPTION
When the configuration is passed as `config_dir`, it filters files not having the yml or yaml extension.

When the configuration is passed directly as a file, it accepts any file (as the user already has edited a YAML and is manually referring to it).

The reason is to allow the Infrastructure Agent passing temporary configuration files, which are created without any extension (as the agent is agnostic to them). Without this patch, Flex is ignoring them.