### PR TITLE
Add example for tracking open and max file descriptors

### DIFF
--- a/examples/flexConfigs/linux-open-fds.yml
+++ b/examples/flexConfigs/linux-open-fds.yml
@@ -1,0 +1,13 @@
+# Used to query Open File Descriptors(FD)
+# mimics nagios check_open_fds
+# does a $1-$2 to be backward compatible with earlier kernels which had available open FDs in column 2
+# newer kernels will have column 1 listing the open FDs and column 2 zero or close to zero
+name: linuxOpenFD
+apis:
+  - name: linuxOpenFD
+    commands:
+      - run: cat /proc/sys/fs/file-nr | awk '{print $1-$2,$3}'
+        split: horizontal
+        set_header: [openFD,maxFD]
+        regex_match: true
+        split_by: (\d+)\s+(.*)


### PR DESCRIPTION
- Used to query Open and Max File Descriptors(FD)
- Mimics nagios check_open_fds
- Does a $1-$2 to be backward compatible with earlier kernels which had available open FDs in column 2
newer kernels will have column 1 listing the open FDs and column 2 zero or close to zero