### PR TITLE
Added discover_process_win  and discover_process_linux

### DIFF
--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -77,7 +77,16 @@ func RunFlex(mode string) {
 	}
 
 	if load.ContainerID == "" && mode != "test" && mode != "lambda" && runtime.GOOS != "darwin" {
-		discovery.Processes()
+		switch runtime.GOOS {
+		case "windows":
+			if load.Args.DiscoverProcessWin {
+				discovery.Processes()
+			}
+		case "linux":
+			if load.Args.DiscoverProcessLinux {
+				discovery.Processes()
+			}
+		}
 	}
 
 	load.Logrus.Info(fmt.Sprintf("flex: config files loaded %d", len(configs)))

--- a/internal/load/README.md
+++ b/internal/load/README.md
@@ -263,6 +263,7 @@ type API struct {
 	RemoveKeys   []string            `yaml:"remove_keys"`
 	KeepKeys     []string            `yaml:"keep_keys"`     // inverse of removing keys
 	SampleFilter []map[string]string `yaml:"sample_filter"` // sample filter key pair values with regex
+	IgnoreOutput bool                `yaml:"ignore_output"` // ignore the output completely, useful when creating lookups
 
 	// Debug Options
 	Debug   bool `yaml:"debug"` // logs out additional data, should not be enabled for production use!
@@ -307,8 +308,10 @@ type ArgumentList struct {
 	GitCommit             string `default:"" help:"Checkout to specified git commit, if set will not use branch"`
 	ProcessConfigsSync    bool   `default:"false" help:"Process configs synchronously rather then async"`
 	// ProcessDiscovery      bool   `default:"true" help:"Enable process discovery"`
-	EncryptPass string `default:"" help:"Pass to be encypted"`
-	PassPhrase  string `default:"N3wR3lic!" help:"PassPhrase used to de/encrypt"`
+	EncryptPass          string `default:"" help:"Pass to be encypted"`
+	PassPhrase           string `default:"N3wR3lic!" help:"PassPhrase used to de/encrypt"`
+	DiscoverProcessWin   bool   `default:"false" help:"Discover Process info on Windows OS"`
+	DiscoverProcessLinux bool   `default:"true" help:"Discover Process info on Linux OS"`
 }
 ```
 

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -45,8 +45,10 @@ type ArgumentList struct {
 	GitCommit             string `default:"" help:"Checkout to specified git commit, if set will not use branch"`
 	ProcessConfigsSync    bool   `default:"false" help:"Process configs synchronously rather then async"`
 	// ProcessDiscovery      bool   `default:"true" help:"Enable process discovery"`
-	EncryptPass string `default:"" help:"Pass to be encypted"`
-	PassPhrase  string `default:"N3wR3lic!" help:"PassPhrase used to de/encrypt"`
+	EncryptPass          string `default:"" help:"Pass to be encypted"`
+	PassPhrase           string `default:"N3wR3lic!" help:"PassPhrase used to de/encrypt"`
+	DiscoverProcessWin   bool   `default:"false" help:"Discover Process info on Windows OS"`
+	DiscoverProcessLinux bool   `default:"true" help:"Discover Process info on Linux OS"`
 }
 
 // Args Infrastructure SDK Arguments List


### PR DESCRIPTION
Added discover_process_win  and discover_process_linux to allow disabling/enabling process info collection. 
- discover_process_win -> default: **false** 
  When setting to **true**, some users may observe high CPU usage with Windows WMI service. 

- discover_process_linux -> default: **true**