### PR TITLE
chore: improve content header check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-sql-driver/mysql v1.4.1
-	github.com/golangci/golangci-lint v1.23.3 // indirect
+	github.com/golangci/golangci-lint v1.23.6 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/jeremywohl/flatten v0.0.0-20180923035001-588fe0d4c603
 	github.com/kardianos/govendor v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/golangci/golangci-lint v1.23.2 h1:WeUpTxmRFK8+MRCJj2Vh0zSdIZvIcrFufQj
 github.com/golangci/golangci-lint v1.23.2/go.mod h1:LNexeEyqT5hQH7v47e67JekL0V51lXFUjbPkopxNSK4=
 github.com/golangci/golangci-lint v1.23.3 h1:wkACDEoy+b0CVqnSK8BbWrVkN2tsVLUA1+SIkGSm4o0=
 github.com/golangci/golangci-lint v1.23.3/go.mod h1:LNexeEyqT5hQH7v47e67JekL0V51lXFUjbPkopxNSK4=
+github.com/golangci/golangci-lint v1.23.6 h1:dxnT1QFIpTeVoFUPaVDeFJJ+To++8ANYsQ2JIxJY02s=
+github.com/golangci/golangci-lint v1.23.6/go.mod h1:g/38bxfhp4rI7zeWSxcdIeHTQGS58TCak8FYcyCmavQ=
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc h1:gLLhTLMk2/SutryVJ6D4VZCU3CUqr8YloG7FPIBWFpI=
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc/go.mod h1:e5tpTHCfVze+7EpLEozzMB3eafxo2KT5veNg1k6byQU=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
@@ -585,6 +587,8 @@ golang.org/x/tools v0.0.0-20191113232020-e2727e816f5a h1:3IG7HNvPBDvrxpnTWA6zpeN
 golang.org/x/tools v0.0.0-20191113232020-e2727e816f5a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200102140908-9497f49d5709 h1:AfG1EmoRkFK24HWWLxSrRKNg2G+oA3JVOG8GJsHWypQ=
 golang.org/x/tools v0.0.0-20200102140908-9497f49d5709/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200204192400-7124308813f3 h1:Ms82wn6YK4ZycO6Bxyh0kxX3gFFVGo79CCuc52xgcys=
+golang.org/x/tools v0.0.0-20200204192400-7124308813f3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=

--- a/internal/inputs/http.go
+++ b/internal/inputs/http.go
@@ -92,7 +92,7 @@ func RunHTTP(dataStore *[]interface{}, doLoop *bool, yml *load.Config, api load.
 			case contentType == "text/xml" || contentType == "application/xml":
 				jsonBody, err := xj.Convert(resp.Body)
 				if err != nil {
-					load.Logrus.WithError(err).Error("http: URL %v failed to convert XML to Json resp.Body", *reqURL)
+					load.Logrus.WithError(err).Errorf("http: URL %v failed to convert XML to Json resp.Body", *reqURL)
 				} else {
 					if api.Pagination.OriginalURL == "" || (api.Pagination.OriginalURL != "" && resp.StatusCode >= 200 && resp.StatusCode <= 299) {
 						handleJSON(dataStore, jsonBody.Bytes(), &resp, doLoop, reqURL, nextLink)

--- a/internal/inputs/http.go
+++ b/internal/inputs/http.go
@@ -92,9 +92,7 @@ func RunHTTP(dataStore *[]interface{}, doLoop *bool, yml *load.Config, api load.
 			case contentType == "text/xml" || contentType == "application/xml":
 				jsonBody, err := xj.Convert(resp.Body)
 				if err != nil {
-					load.Logrus.WithFields(logrus.Fields{
-						"err": err,
-					}).Errorf("http: URL %v failed to convert XML to Json resp.Body", *reqURL)
+					load.Logrus.WithError(err).Error("http: URL %v failed to convert XML to Json resp.Body", *reqURL)
 				} else {
 					if api.Pagination.OriginalURL == "" || (api.Pagination.OriginalURL != "" && resp.StatusCode >= 200 && resp.StatusCode <= 299) {
 						handleJSON(dataStore, jsonBody.Bytes(), &resp, doLoop, reqURL, nextLink)


### PR DESCRIPTION
- use equals instead of contains for json contentType check
- add xml contenType check (without this when it falls through the switch and attempts to check the payload, the XML check is not always reliable when the `<xml` tag is not present.)