### PR TITLE
feat: read v4 agent integrations config format to ensure config_file arg is fully supported

### DIFF
--- a/cmd/nri-flex/nri-flex_test.go
+++ b/cmd/nri-flex/nri-flex_test.go
@@ -29,6 +29,7 @@ func testSamples(expectedSamples []string, entityMetrics []*metric.Set, t *testi
 			delete(sample.Metrics, "flex.time.startMs")
 			delete(sample.Metrics, "flex.time.endMs")
 			delete(sample.Metrics, "flex.time.elaspedMs")
+			delete(sample.Metrics, "flex.commandTimeMs")
 			out, err := sample.MarshalJSON()
 			if err != nil {
 				load.Logrus.WithFields(logrus.Fields{
@@ -53,7 +54,9 @@ func TestConfigDir(t *testing.T) {
 	load.Args.ConfigDir = "../../test/configs/"
 	fintegration.RunFlex(fintegration.FlexModeTest)
 	expectedSamples := []string{
-		`{"event_type":"flexStatusSample","flex.IntegrationVersion":"Unknown-SNAPSHOT","flex.counter.ConfigsProcessed":1,"flex.counter.EventCount":1,"flex.counter.EventDropCount":0,"flex.counter.commandJsonOutSample":1}`,
+		`{"event_type":"flexStatusSample","flex.IntegrationVersion":"Unknown-SNAPSHOT","flex.counter.ConfigsProcessed":3,"flex.counter.EventCount":3,"flex.counter.EventDropCount":0,"flex.counter.MessageSample":2,"flex.counter.commandJsonOutSample":1}`,
+		`{"error":"true","event_type":"MessageSample","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT","message":"bye","value":20.9}`,
+		`{"error":"false","event_type":"MessageSample","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT","message":"hello","value":100}`,
 		`{"completed":"false","event_type":"commandJsonOutSample","id":1,"integration_name":"com.newrelic.nri-flex",` +
 			`"integration_version":"Unknown-SNAPSHOT","myCustomAttr":"theValue","title":"delectus aut autem","userId":1}`}
 	testSamples(expectedSamples, load.Entity.Metrics, t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,47 @@ func LoadFiles(configs *[]load.Config, files []os.FileInfo, path string) []error
 	return errors
 }
 
+// LoadV4IntegrationConfig Loads Agent/Flex config files
+func LoadV4IntegrationConfig(v4Str string, configs *[]load.Config, fileName string, filePath string) error {
+	c := load.AgentConfig{}
+	err := yaml.Unmarshal([]byte(v4Str), &c)
+
+	if err != nil {
+		load.Logrus.WithError(err).Error("config: failed to unmarshal v4 config file")
+		return err
+	}
+
+	for _, integration := range c.Integrations {
+		// ensure it is a flex based integration
+		if integration.Name == "nri-flex" {
+			newConfig := integration.Config
+			newConfig.FileName = fileName
+			newConfig.FilePath = filePath
+
+			if newConfig.Name == "" {
+				load.Logrus.WithFields(logrus.Fields{
+					"file": filePath,
+				}).WithError(err).Error("config: flexConfig requires name")
+				return err
+			}
+
+			// if lookup files exist we need to potentially create multiple config files
+			if newConfig.LookupFile != "" {
+				err = SubLookupFileData(configs, newConfig)
+				if err != nil {
+					load.Logrus.WithFields(logrus.Fields{
+						"file": filePath,
+					}).WithError(err).Error("config: failed to sub lookup file data")
+				}
+			} else {
+				*configs = append(*configs, newConfig)
+			}
+		}
+	}
+
+	return nil
+}
+
 // LoadFile loads a single Flex config file
 func LoadFile(configs *[]load.Config, f os.FileInfo, path string) error {
 	filePath := path + f.Name()
@@ -60,35 +101,47 @@ func LoadFile(configs *[]load.Config, f os.FileInfo, path string) error {
 	ymlStr := string(b)
 	SubEnvVariables(&ymlStr)
 	SubTimestamps(&ymlStr, time.Now())
-	config, err := ReadYML(ymlStr)
-	if err != nil {
-		load.Logrus.WithFields(logrus.Fields{
-			"file": filePath,
-		}).WithError(err).Error("config: failed to load config file")
-		return err
-	}
 
-	config.FileName = f.Name()
-	config.FilePath = path
-	if config.Name == "" {
-		load.Logrus.WithFields(logrus.Fields{
-			"file": filePath,
-		}).WithError(err).Error("config: flexConfig requires name")
-		return err
-	}
-
-	checkIngestConfigs(&config)
-
-	// if lookup files exist we need to potentially create multiple config files
-	if config.LookupFile != "" {
-		err = SubLookupFileData(configs, config)
+	// Check if V4 Agent configuration
+	if strings.HasPrefix(ymlStr, "integrations:") {
+		err := LoadV4IntegrationConfig(ymlStr, configs, f.Name(), path)
 		if err != nil {
 			load.Logrus.WithFields(logrus.Fields{
 				"file": filePath,
-			}).WithError(err).Error("config: failed to sub lookup file data")
+			}).WithError(err).Error("config: failed to load v4 config file")
+			return err
 		}
 	} else {
-		*configs = append(*configs, config)
+		config, err := ReadYML(ymlStr)
+		if err != nil {
+			load.Logrus.WithFields(logrus.Fields{
+				"file": filePath,
+			}).WithError(err).Error("config: failed to load config file")
+			return err
+		}
+
+		config.FileName = f.Name()
+		config.FilePath = path
+		if config.Name == "" {
+			load.Logrus.WithFields(logrus.Fields{
+				"file": filePath,
+			}).WithError(err).Error("config: flexConfig requires name")
+			return err
+		}
+
+		checkIngestConfigs(&config)
+
+		// if lookup files exist we need to potentially create multiple config files
+		if config.LookupFile != "" {
+			err = SubLookupFileData(configs, config)
+			if err != nil {
+				load.Logrus.WithFields(logrus.Fields{
+					"file": filePath,
+				}).WithError(err).Error("config: failed to sub lookup file data")
+			}
+		} else {
+			*configs = append(*configs, config)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,6 +106,31 @@ func TestConfigFile(t *testing.T) {
 	testSamples(expectedOutput, t)
 }
 
+func TestV4ConfigFile(t *testing.T) {
+	load.Refresh()
+	i, _ := integration.New(load.IntegrationName, load.IntegrationVersion)
+	load.Entity, _ = i.Entity("TestV4Cmd", "nri-flex")
+	load.Args.ConfigFile = "../../test/configs/v4-integrations-example.yml"
+
+	// Read a single config file
+	var files []os.FileInfo
+	var ymls []load.Config
+	file, _ := os.Stat(load.Args.ConfigFile)
+	path := strings.Replace(filepath.FromSlash(load.Args.ConfigFile), file.Name(), "", -1)
+	files = append(files, file)
+
+	LoadFiles(&ymls, files, path) // load standard configs if available
+	RunFiles(&ymls)
+
+	jsonFile, _ := ioutil.ReadFile("../../test/payloadsExpected/configFileV4.json")
+	expectedOutput := []*metric.Set{}
+	err := json.Unmarshal(jsonFile, &expectedOutput)
+	if err != nil {
+		t.Error(err)
+	}
+	testSamples(expectedOutput, t)
+}
+
 func TestSubEnvVariables(t *testing.T) {
 	str := " hi there $$PWD bye"
 	SubEnvVariables(&str)

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -156,6 +156,18 @@ type Metrics struct {
 	Metrics          []map[string]interface{} `json:"metrics"` // summaries have a different value structure then gauges or counters
 }
 
+// AgentConfig stores the information from a single V4 integrations file
+// This has been added so that Flex can understand the V4 agent format when users are using the config_file parameter
+type AgentConfig struct {
+	Integrations []ConfigEntry `yaml:"integrations"`
+}
+
+// ConfigEntry holds an integrations YAML configuration entry. It may define multiple types of tasks
+type ConfigEntry struct {
+	Name   string `yaml:"name"`
+	Config Config `yaml:"config"`
+}
+
 // Config YAML Struct
 type Config struct {
 	FileName           string             `yaml:"file_name"`           // set when file is read

--- a/test/configs/v4-integrations-example.yml
+++ b/test/configs/v4-integrations-example.yml
@@ -1,0 +1,17 @@
+integrations:
+  - name: nri-flex
+    config:
+      name: splitByTest
+      apis:
+        - name: Message
+          commands:
+            - run: printf "message:hello\nvalue:100\nerror:false\n"
+              split_by: ":"
+  - name: nri-flex
+    config:
+      name: splitByTest
+      apis:
+        - name: Message
+          commands:
+            - run: printf "message::bye\nvalue::20.9\nerror::true\n"
+              split_by: "::"

--- a/test/payloadsExpected/configFileV4.json
+++ b/test/payloadsExpected/configFileV4.json
@@ -1,15 +1,5 @@
 [
     {
-        "completed": "false",
-        "event_type": "commandJsonOutSample",
-        "id": 1,
-        "integration_name": "com.newrelic.nri-flex",
-        "integration_version": "Unknown-SNAPSHOT",
-        "myCustomAttr": "theValue",
-        "title": "delectus aut autem",
-        "userId": 1
-    },
-    {
         "error": "false",
         "event_type": "MessageSample",
         "integration_name": "com.newrelic.nri-flex",


### PR DESCRIPTION
With users migrating to the GA Version of Flex were we are suggesting to use the new V4 Integrations format, the config_file argument does not understand that agents V4 integrations yaml configuration, so it fails to work properly for users. 

This is where we see many users trying to pass a single config file, and Flex returns that it requires a name for the config as it doesn't understand that format. Which in turn makes it harder to debug single configs.

Fixes #108 . 

cc/ @bpschmitt @haihongren 