### PR TITLE
Zack windows ping

### DIFF
--- a/examples/flexConfigs/windows-ping-example.yml
+++ b/examples/flexConfigs/windows-ping-example.yml
@@ -1,0 +1,12 @@
+# This config will execute a script to emulate the PING output from Linux
+# Use forward slashes on Windows paths as Flex handles these more gracefully
+# Note we have manually created a 'flexAssets' directory to hold scripts and lookup files
+# lookup_file: https://github.com/newrelic/nri-flex/blob/master/docs/basics/functions.md#lookup_file
+# shell: https://github.com/newrelic/nri-flex/blob/master/docs/apis/commands.md#specify-the-shell
+name: winPing
+lookup_file: "C:/Program Files/New Relic/newrelic-infra/integrations.d/flexAssets/windows-ping-lookup.json"
+apis:
+  - name: winPing
+    shell: powershell
+    commands:
+      - run: "& \"C:/Program Files/New Relic/newrelic-infra/integrations.d/flexAssets/windows-ping-script\" -Target ${lf:target} -Count ${lf:count}"

--- a/examples/flexConfigs/windows-ping-lookup.json
+++ b/examples/flexConfigs/windows-ping-lookup.json
@@ -1,0 +1,14 @@
+[
+	{
+		"target":"www.google.com",
+		"count": "4"
+	},
+	{
+		"target":"www.newrelic.com",
+		"count": "5"
+	},
+	{
+		"target":"www.thisismeantto.fail",
+		"count": "7"
+	}
+]

--- a/examples/flexConfigs/windows-ping-script.ps1
+++ b/examples/flexConfigs/windows-ping-script.ps1
@@ -1,0 +1,82 @@
+#region Top of Script
+
+#requires -version 3
+
+<#
+.SYNOPSIS
+	Tests connection to target endpoint using Test-Connection cmdlet
+.DESCRIPTION
+	This script will emulate the output of the 'ping' utility in Linux systems
+  The -Count argument allows you to specify the number of packets being sent
+.EXAMPLE
+	.\windows-ping-script.ps1 -Target "www.newrelic.com" -Count 5
+.NOTES
+	Version:		1.0
+	Author:			Zack Mutchler
+	Creation Date:	03/24/2020
+	Purpose/Change:	Initial script development
+#>
+
+#endregion
+
+#####-----------------------------------------------------------------------------------------#####
+
+#region Script Parameters
+
+Param
+	(
+		
+        [ Parameter( Mandatory = $true ) ] [ string ] $Target,
+		[ Parameter( Mandatory = $true ) ] [ int ] $Count
+
+	)
+
+#endregion Script Parameters
+
+#####-----------------------------------------------------------------------------------------#####
+
+#region Execution
+
+# Build an empty object to hold our results
+$results = New-Object -TypeName psobject
+
+# Test the connection
+$ping = Test-Connection -ComputerName $target -Count $count -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+
+# If the test fails, manually set the output
+if( !( $ping ) ) { 
+
+    $results | Add-Member -MemberType NoteProperty -Name "target" -Value $target 
+    $results | Add-Member -MemberType NoteProperty -Name "packetLoss" -Value 100
+    $results | Add-Member -MemberType NoteProperty -Name "packetsReceived" -Value 0
+    $results | Add-Member -MemberType NoteProperty -Name "packetsTransmitted" -Value $count 
+    $results | Add-Member -MemberType NoteProperty -Name "avgResponse" -Value 0
+    $results | Add-Member -MemberType NoteProperty -Name "minResponse" -Value 0
+    $results | Add-Member -MemberType NoteProperty -Name "maxResponse" -Value 0
+    
+} 
+
+# Otherwise, add data to our results
+else {
+
+    # Calculate the response time summary
+    $responseTime = $ping | Measure-Object -Property ResponseTime -Minimum -Maximum -Average
+    
+    # Calculate packet loss percentage
+    $packetLoss = ( ( $count - $responseTime.Count ) / $count ) * 100
+
+    # Fill our results array
+    $results | Add-Member -MemberType NoteProperty -Name "target" -Value $target 
+    $results | Add-Member -MemberType NoteProperty -Name "packetLoss" -Value $packetLoss 
+    $results | Add-Member -MemberType NoteProperty -Name "packetsReceived" -Value $responseTime.Count 
+    $results | Add-Member -MemberType NoteProperty -Name "packetsTransmitted" -Value $count 
+    $results | Add-Member -MemberType NoteProperty -Name "avgResponse" -Value $responseTime.Average
+    $results | Add-Member -MemberType NoteProperty -Name "minResponse" -Value $responseTime.Minimum
+    $results | Add-Member -MemberType NoteProperty -Name "maxResponse" -Value $responseTime.Maximum
+
+}
+
+# Print the results to STDOUT in JSON format
+$results | ConvertTo-Json
+
+#endregion Execution


### PR DESCRIPTION
adding example for executing 'ping' in Windows to replicate output of the 'ping' function in Linux. this should resolve Issue #125 

output example: 
```json
{
        "name": "com.newrelic.nri-flex",
        "protocol_version": "3",
        "integration_version": "1.1.0",
        "data": [
                {
                        "metrics": [
                                {
                                        "avgResponse": 0.75,
                                        "event_type": "winPingSample",
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "1.1.0",
                                        "maxResponse": 2,
                                        "minResponse": 0,
                                        "packetLoss": 0,
                                        "packetsReceived": 4,
                                        "packetsTransmitted": 4,
                                        "target": "www.google.com"
                                },
                                {
                                        "avgResponse": 0.4,
                                        "event_type": "winPingSample",
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "1.1.0",
                                        "maxResponse": 1,
                                        "minResponse": 0,
                                        "packetLoss": 0,
                                        "packetsReceived": 5,
                                        "packetsTransmitted": 5,
                                        "target": "www.newrelic.com"
                                },
                                {
                                        "avgResponse": 0,
                                        "event_type": "winPingSample",
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "1.1.0",
                                        "maxResponse": 0,
                                        "minResponse": 0,
                                        "packetLoss": 100,
                                        "packetsReceived": 0,
                                        "packetsTransmitted": 7,
                                        "target": "www.thisismeantto.fail"
                                },
                                {
                                        "event_type": "flexStatusSample",
                                        "flex.Hostname": "win-solarwinds",
                                        "flex.IntegrationVersion": "1.1.0",
                                        "flex.counter.ConfigsProcessed": 3,
                                        "flex.counter.EventCount": 3,
                                        "flex.counter.EventDropCount": 0,
                                        "flex.counter.winPingSample": 3,
                                        "flex.time.elaspedMs": 8569,
                                        "flex.time.endMs": 1585067036292,
                                        "flex.time.startMs": 1585067027723
                                }
                        ],
                        "inventory": {},
                        "events": []
                }
        ]
}
```