### PR TITLE
chore: move lookup creation after addAttribute

### DIFF
--- a/internal/processor/create.go
+++ b/internal/processor/create.go
@@ -6,17 +6,18 @@
 package processor
 
 import (
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/nri-flex/internal/formatter"
 	"github.com/newrelic/nri-flex/internal/load"
 	"github.com/newrelic/nri-flex/internal/outputs"
-	"regexp"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 const regex = "regex"
@@ -83,21 +84,6 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int, mergeMe
 				delete(currentSample, k)
 			}
 
-			// if run_async is set to true for the API, we will skip StoreLookups and VariableLookups processing due to potential concurrent map write operation
-			// we will address this in the future. However, for run_async=true usecase, we do not expect these two functions to be used.
-			if !api.RunAsync {
-				StoreLookups(api.StoreLookups, &key, &config.LookupStore, &v)        // store lookups
-				VariableLookups(api.StoreVariables, &key, &config.VariableStore, &v) // store variable
-			}
-			// else {
-			// 	load.Logrus.WithFields(logrus.Fields{
-			// 		"API name":  api.Name,
-			// 		"run_async": api.RunAsync,
-			// 		"key":       key,
-			// 	}).Debug("create: skipping StoreLookups VariableLookups due to run_async is true: ")
-
-			// }
-
 			// if keepkeys used will do inverse
 			RunKeepKeys(api.KeepKeys, &key, &currentSample)
 			RunSampleRenamer(api.RenameSamples, &currentSample, key, &eventType)
@@ -144,7 +130,26 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int, mergeMe
 				currentSample["baseUrl"] = config.Global.BaseURL
 			}
 
+			// addAttribute is kept outside the first currentSample loop intentionally
+			// if an attribute is added to the currentSample while in the loop it will restart the loop
 			addAttribute(currentSample, api.AddAttribute)
+
+			// lookups should be performed after addAttribute to ensure anything constructed is available for lookup creation
+			// if run_async is set to true for the API, we will skip StoreLookups and VariableLookups processing due to potential concurrent map write operation
+			// we will address this in the future. However, for run_async=true usecase, we do not expect these two functions to be used.
+			if !api.RunAsync {
+				for k, v := range currentSample {
+					StoreLookups(api.StoreLookups, &config.LookupStore, k, v)        // store lookups
+					VariableLookups(api.StoreVariables, &config.VariableStore, k, v) // store variable
+				}
+			}
+			// else {
+			// 	load.Logrus.WithFields(logrus.Fields{
+			// 		"API name":  api.Name,
+			// 		"run_async": api.RunAsync,
+			// 		"key":       key,
+			// 	}).Debug("create: skipping StoreLookups VariableLookups due to run_async is true: ")
+			// }
 
 			// remove keys from sample
 			// this should be kept last

--- a/internal/processor/create.go
+++ b/internal/processor/create.go
@@ -89,6 +89,27 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int, mergeMe
 			RunSampleRenamer(api.RenameSamples, &currentSample, key, &eventType)
 		}
 
+		// addAttribute is kept outside the first currentSample loop intentionally
+		// if an attribute is added to the currentSample while in the loop it will restart the loop
+		addAttribute(currentSample, api.AddAttribute)
+
+		// lookups should be performed after addAttribute to ensure anything constructed is available for lookup creation
+		// if run_async is set to true for the API, we will skip StoreLookups and VariableLookups processing due to potential concurrent map write operation
+		// we will address this in the future. However, for run_async=true usecase, we do not expect these two functions to be used.
+		if !api.RunAsync {
+			for k, v := range currentSample {
+				StoreLookups(api.StoreLookups, &config.LookupStore, k, v)        // store lookups
+				VariableLookups(api.StoreVariables, &config.VariableStore, k, v) // store variable
+			}
+		}
+		// else {
+		// 	load.Logrus.WithFields(logrus.Fields{
+		// 		"API name":  api.Name,
+		// 		"run_async": api.RunAsync,
+		// 		"key":       key,
+		// 	}).Debug("create: skipping StoreLookups VariableLookups due to run_async is true: ")
+		// }
+
 		createSample := false
 		runSampleFilterExperimental := true
 		// check if we should ignore this output completely
@@ -129,27 +150,6 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int, mergeMe
 			if config.Global.BaseURL != "" {
 				currentSample["baseUrl"] = config.Global.BaseURL
 			}
-
-			// addAttribute is kept outside the first currentSample loop intentionally
-			// if an attribute is added to the currentSample while in the loop it will restart the loop
-			addAttribute(currentSample, api.AddAttribute)
-
-			// lookups should be performed after addAttribute to ensure anything constructed is available for lookup creation
-			// if run_async is set to true for the API, we will skip StoreLookups and VariableLookups processing due to potential concurrent map write operation
-			// we will address this in the future. However, for run_async=true usecase, we do not expect these two functions to be used.
-			if !api.RunAsync {
-				for k, v := range currentSample {
-					StoreLookups(api.StoreLookups, &config.LookupStore, k, v)        // store lookups
-					VariableLookups(api.StoreVariables, &config.VariableStore, k, v) // store variable
-				}
-			}
-			// else {
-			// 	load.Logrus.WithFields(logrus.Fields{
-			// 		"API name":  api.Name,
-			// 		"run_async": api.RunAsync,
-			// 		"key":       key,
-			// 	}).Debug("create: skipping StoreLookups VariableLookups due to run_async is true: ")
-			// }
 
 			// remove keys from sample
 			// this should be kept last

--- a/internal/processor/lookups.go
+++ b/internal/processor/lookups.go
@@ -22,19 +22,19 @@ func cleanValue(v *interface{}) string {
 }
 
 // StoreLookups if key is found (using regex), store the values in the lookupStore as the defined lookupStoreKey for later use
-func StoreLookups(storeLookups map[string]string, key *string, lookupStore *map[string]map[string]struct{}, v *interface{}) {
+func StoreLookups(storeLookups map[string]string, lookupStore *map[string]map[string]struct{}, key string, v interface{}) {
 	for lookupStoreKey, lookupFindKey := range storeLookups {
-		if *key == lookupFindKey {
+		if key == lookupFindKey {
 			load.Logrus.WithFields(logrus.Fields{
 				"lookupFindKey": lookupFindKey,
-				lookupStoreKey:  fmt.Sprintf("%v", *v),
+				lookupStoreKey:  fmt.Sprintf("%v", v),
 			}).Debug("create: store lookup")
 
 			if (*lookupStore)[lookupStoreKey] == nil {
 				(*lookupStore)[lookupStoreKey] = make(map[string]struct{})
 			}
 
-			switch data := (*v).(type) {
+			switch data := (v).(type) {
 			case []interface{}:
 				load.Logrus.WithFields(logrus.Fields{
 					"lookupFindKey": lookupFindKey,
@@ -44,20 +44,20 @@ func StoreLookups(storeLookups map[string]string, key *string, lookupStore *map[
 					(*lookupStore)[lookupStoreKey][cleanValue(&dataKey)] = struct{}{}
 				}
 			default:
-				(*lookupStore)[lookupStoreKey][cleanValue(v)] = struct{}{}
+				(*lookupStore)[lookupStoreKey][cleanValue(&v)] = struct{}{}
 			}
 		}
 	}
 }
 
 // VariableLookups if key is found (using regex), store the value in the variableStore, as the defined by the variableStoreKey for later use
-func VariableLookups(variableLookups map[string]string, key *string, variableStore *map[string]string, v *interface{}) {
+func VariableLookups(variableLookups map[string]string, variableStore *map[string]string, key string, v interface{}) {
 	for variableStoreKey, variableFindKey := range variableLookups {
-		if *key == variableFindKey {
+		if key == variableFindKey {
 			if (*variableStore) == nil {
 				(*variableStore) = map[string]string{}
 			}
-			(*variableStore)[variableStoreKey] = cleanValue(v)
+			(*variableStore)[variableStoreKey] = cleanValue(&v)
 		}
 	}
 }

--- a/internal/processor/lookups_test.go
+++ b/internal/processor/lookups_test.go
@@ -20,7 +20,7 @@ func TestStoreLookups(t *testing.T) {
 	var v interface{}
 	v = "myStoredValue"
 
-	StoreLookups(storeLookups, &key, &lookupStore, &v)
+	StoreLookups(storeLookups, &lookupStore, key, v)
 	valueArray := []string{}
 	for a := range lookupStore["blah"] {
 		valueArray = append(valueArray, a)
@@ -40,7 +40,7 @@ func TestVariableLookups(t *testing.T) {
 	var v interface{}
 	v = "myStoredValue"
 
-	VariableLookups(storeLookups, &key, &variableStore, &v)
+	VariableLookups(storeLookups, &variableStore, key, v)
 
 	if fmt.Sprintf("%v", variableStore["blah"]) != v {
 		t.Errorf("want: %v got: %v", v, variableStore["blah"])


### PR DESCRIPTION
* change allows `add_attribute` to work with `store_lookups` 
* there is no functional change to how lookups function other then reordering the execution

Notes: required due to internal escalation