### PR TITLE
fix/update: avoid incomplete lookups & allow lookup from previous data

### DIFF
--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -64,6 +64,9 @@ var StartTime int64
 // Integration Infrastructure SDK Integration
 var Integration *integration.Integration
 
+// IgnoredIntegrationData this is used for lookups with ignored output
+var IgnoredIntegrationData []map[string]interface{}
+
 // Entity Infrastructure SDK Entity
 var Entity *integration.Entity
 
@@ -281,6 +284,7 @@ type API struct {
 	DisableParentAttr bool              `yaml:"disable_parent_attr"`
 	StartKey          []string          `yaml:"start_key"` // start from a different section of the payload
 	StoreLookups      map[string]string `yaml:"store_lookups"`
+	DedupeLookups     []string          `yaml:"dedupe_lookups"`
 	StoreVariables    map[string]string `yaml:"store_variables"`
 	LazyFlatten       []string          `yaml:"lazy_flatten"`
 	SampleKeys        map[string]string `yaml:"sample_keys"`

--- a/internal/processor/create.go
+++ b/internal/processor/create.go
@@ -6,17 +6,18 @@
 package processor
 
 import (
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/nri-flex/internal/formatter"
 	"github.com/newrelic/nri-flex/internal/load"
 	"github.com/newrelic/nri-flex/internal/outputs"
-	"regexp"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 const regex = "regex"
@@ -83,25 +84,31 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int, mergeMe
 				delete(currentSample, k)
 			}
 
-			// if run_async is set to true for the API, we will skip StoreLookups and VariableLookups processing due to potential concurrent map write operation
-			// we will address this in the future. However, for run_async=true usecase, we do not expect these two functions to be used.
-			if !api.RunAsync {
-				StoreLookups(api.StoreLookups, &key, &config.LookupStore, &v)        // store lookups
-				VariableLookups(api.StoreVariables, &key, &config.VariableStore, &v) // store variable
-			}
-			// else {
-			// 	load.Logrus.WithFields(logrus.Fields{
-			// 		"API name":  api.Name,
-			// 		"run_async": api.RunAsync,
-			// 		"key":       key,
-			// 	}).Debug("create: skipping StoreLookups VariableLookups due to run_async is true: ")
-
-			// }
-
 			// if keepkeys used will do inverse
 			RunKeepKeys(api.KeepKeys, &key, &currentSample)
 			RunSampleRenamer(api.RenameSamples, &currentSample, key, &eventType)
 		}
+
+		// addAttribute is kept outside the first currentSample loop intentionally
+		// if an attribute is added to the currentSample while in the loop it will restart the loop
+		addAttribute(currentSample, api.AddAttribute)
+
+		// lookups should be performed after addAttribute to ensure anything constructed is available for lookup creation
+		// if run_async is set to true for the API, we will skip StoreLookups and VariableLookups processing due to potential concurrent map write operation
+		// we will address this in the future. However, for run_async=true usecase, we do not expect these two functions to be used.
+		if !api.RunAsync {
+			for k, v := range currentSample {
+				StoreLookups(api.StoreLookups, &config.LookupStore, k, v)        // store lookups
+				VariableLookups(api.StoreVariables, &config.VariableStore, k, v) // store variable
+			}
+		}
+		// else {
+		// 	load.Logrus.WithFields(logrus.Fields{
+		// 		"API name":  api.Name,
+		// 		"run_async": api.RunAsync,
+		// 		"key":       key,
+		// 	}).Debug("create: skipping StoreLookups VariableLookups due to run_async is true: ")
+		// }
 
 		createSample := false
 		runSampleFilterExperimental := true
@@ -109,6 +116,8 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int, mergeMe
 		// useful when requests are made to generate a lookup, but the data is not needed
 		if api.IgnoreOutput {
 			createSample = false
+			currentSample["event_type"] = eventType
+			load.IgnoredIntegrationData = append(load.IgnoredIntegrationData, currentSample)
 		} else {
 			// check if this contains any key pair values to filter out
 			excludeSample := true
@@ -143,8 +152,6 @@ func CreateMetricSets(samples []interface{}, config *load.Config, i int, mergeMe
 			if config.Global.BaseURL != "" {
 				currentSample["baseUrl"] = config.Global.BaseURL
 			}
-
-			addAttribute(currentSample, api.AddAttribute)
 
 			// remove keys from sample
 			// this should be kept last

--- a/internal/processor/lookups.go
+++ b/internal/processor/lookups.go
@@ -22,19 +22,19 @@ func cleanValue(v *interface{}) string {
 }
 
 // StoreLookups if key is found (using regex), store the values in the lookupStore as the defined lookupStoreKey for later use
-func StoreLookups(storeLookups map[string]string, key *string, lookupStore *map[string]map[string]struct{}, v *interface{}) {
+func StoreLookups(storeLookups map[string]string, lookupStore *map[string]map[string]struct{}, key string, v interface{}) {
 	for lookupStoreKey, lookupFindKey := range storeLookups {
-		if *key == lookupFindKey {
+		if key == lookupFindKey {
 			load.Logrus.WithFields(logrus.Fields{
 				"lookupFindKey": lookupFindKey,
-				lookupStoreKey:  fmt.Sprintf("%v", *v),
+				lookupStoreKey:  fmt.Sprintf("%v", v),
 			}).Debug("create: store lookup")
 
 			if (*lookupStore)[lookupStoreKey] == nil {
 				(*lookupStore)[lookupStoreKey] = make(map[string]struct{})
 			}
 
-			switch data := (*v).(type) {
+			switch data := (v).(type) {
 			case []interface{}:
 				load.Logrus.WithFields(logrus.Fields{
 					"lookupFindKey": lookupFindKey,
@@ -44,20 +44,20 @@ func StoreLookups(storeLookups map[string]string, key *string, lookupStore *map[
 					(*lookupStore)[lookupStoreKey][cleanValue(&dataKey)] = struct{}{}
 				}
 			default:
-				(*lookupStore)[lookupStoreKey][cleanValue(v)] = struct{}{}
+				(*lookupStore)[lookupStoreKey][cleanValue(&v)] = struct{}{}
 			}
 		}
 	}
 }
 
 // VariableLookups if key is found (using regex), store the value in the variableStore, as the defined by the variableStoreKey for later use
-func VariableLookups(variableLookups map[string]string, key *string, variableStore *map[string]string, v *interface{}) {
+func VariableLookups(variableLookups map[string]string, variableStore *map[string]string, key string, v interface{}) {
 	for variableStoreKey, variableFindKey := range variableLookups {
-		if *key == variableFindKey {
+		if key == variableFindKey {
 			if (*variableStore) == nil {
 				(*variableStore) = map[string]string{}
 			}
-			(*variableStore)[variableStoreKey] = cleanValue(v)
+			(*variableStore)[variableStoreKey] = cleanValue(&v)
 		}
 	}
 }

--- a/internal/processor/lookups_test.go
+++ b/internal/processor/lookups_test.go
@@ -20,7 +20,7 @@ func TestStoreLookups(t *testing.T) {
 	var v interface{}
 	v = "myStoredValue"
 
-	StoreLookups(storeLookups, &key, &lookupStore, &v)
+	StoreLookups(storeLookups, &lookupStore, key, v)
 	valueArray := []string{}
 	for a := range lookupStore["blah"] {
 		valueArray = append(valueArray, a)
@@ -40,7 +40,7 @@ func TestVariableLookups(t *testing.T) {
 	var v interface{}
 	v = "myStoredValue"
 
-	VariableLookups(storeLookups, &key, &variableStore, &v)
+	VariableLookups(storeLookups, &variableStore, key, v)
 
 	if fmt.Sprintf("%v", variableStore["blah"]) != v {
 		t.Errorf("want: %v got: %v", v, variableStore["blah"])


### PR DESCRIPTION
* avoid incomplete lookups
* allow creating lookups from previously generated data 
* * avoids creating lookups manually and redefining subsequent times
* allow lookups to be deduplicated 
* all current features and tests are still valid and compatible
* minor code clean up

Notes: required for escalation