### PR TITLE
marking examples with experimental functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Community Project header](https://github.com/newrelic/open-source-office/raw/master/examples/categories/images/Community_Project.png)](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#category-community-project)
+
 # New Relic Flex
 
 [![Build Status](https://travis-ci.org/newrelic/nri-flex.svg?branch=master)](https://travis-ci.org/newrelic/nri-flex)

--- a/examples/flexConfigs/cd-redis.yml
+++ b/examples/flexConfigs/cd-redis.yml
@@ -1,3 +1,7 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
+# NOTE: 'metric_parser' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 name: redisFlex
 apis: 

--- a/examples/flexConfigs/circleci-http-example.yml
+++ b/examples/flexConfigs/circleci-http-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'sample_keys' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # https://circleci.com/docs/api/
 ---
 integrations:

--- a/examples/flexConfigs/ecs-task-state-changes-lambda.yml
+++ b/examples/flexConfigs/ecs-task-state-changes-lambda.yml
@@ -1,3 +1,5 @@
+# NOTE: 'inherit_attributes' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ### this file should be renamed to "flex-lambda-ingest.yml"
 ### set a cloudwatch event to trigger the lamda for ECS state changes
 ---

--- a/examples/flexConfigs/elasticsearch-http-example.yml
+++ b/examples/flexConfigs/elasticsearch-http-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'sample_keys' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
 ---
 integrations:

--- a/examples/flexConfigs/eventstore.yml
+++ b/examples/flexConfigs/eventstore.yml
@@ -1,3 +1,5 @@
+# NOTE: 'sample_keys' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/hana-database-example.yml
+++ b/examples/flexConfigs/hana-database-example.yml
@@ -1,4 +1,4 @@
-# NOTE: 'database' is an experimental function at this time
+# NOTE: 'database' is an experimental API at this time
 # ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:

--- a/examples/flexConfigs/hana-database-example.yml
+++ b/examples/flexConfigs/hana-database-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'database' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/mysql-database-example.yml
+++ b/examples/flexConfigs/mysql-database-example.yml
@@ -1,4 +1,4 @@
-# NOTE: 'database' is an experimental function at this time
+# NOTE: 'database' is an experimental API at this time
 # ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:

--- a/examples/flexConfigs/mysql-database-example.yml
+++ b/examples/flexConfigs/mysql-database-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'database' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/pagination-example.yml
+++ b/examples/flexConfigs/pagination-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'pagination' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/port-test-example.yml
+++ b/examples/flexConfigs/port-test-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/port-test-with-lookup.yml
+++ b/examples/flexConfigs/port-test-with-lookup.yml
@@ -1,3 +1,5 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/postgres-db-example.yml
+++ b/examples/flexConfigs/postgres-db-example.yml
@@ -1,4 +1,4 @@
-# NOTE: 'database' is an experimental function at this time
+# NOTE: 'database' is an experimental API at this time
 # ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:

--- a/examples/flexConfigs/postgres-db-example.yml
+++ b/examples/flexConfigs/postgres-db-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'database' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/postgres-stats-example.yml
+++ b/examples/flexConfigs/postgres-stats-example.yml
@@ -1,4 +1,4 @@
-# NOTE: 'database' is an experimental function at this time
+# NOTE: 'database' is an experimental API at this time
 # ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:

--- a/examples/flexConfigs/postgres-stats-example.yml
+++ b/examples/flexConfigs/postgres-stats-example.yml
@@ -1,3 +1,6 @@
+# NOTE: 'database' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
+---
 integrations:
   - name: nri-flex
     config:

--- a/examples/flexConfigs/rabbitmq-http-example.yml
+++ b/examples/flexConfigs/rabbitmq-http-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'metric_parser' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ### https://www.rabbitmq.com/monitoring.html
 ### your.rabbit.server/api/index.html
 ---

--- a/examples/flexConfigs/read-jsonfile-example.yml
+++ b/examples/flexConfigs/read-jsonfile-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'sample_keys' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/redis-cmd-dial-example.yml
+++ b/examples/flexConfigs/redis-cmd-dial-example.yml
@@ -1,3 +1,7 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
+# NOTE: 'metric_parser' and 'sub_parse' are experimental functions at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/redis-cmd-raw-nc-example-old.yml
+++ b/examples/flexConfigs/redis-cmd-raw-nc-example-old.yml
@@ -1,3 +1,5 @@
+# NOTE: 'metric_parser' and 'sub_parse' are experimental functions at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ### note if local testing, macOS does not have the -q flag for nc (netcat) that other linux systems have, so remove if testing locally
 ### if running on linux you may need to add the -q0 flag eg. (printf "info\r\n"; sleep 1) | nc -q0 127.0.0.1 6379
 ---

--- a/examples/flexConfigs/redis-extra-flags-example.yml
+++ b/examples/flexConfigs/redis-extra-flags-example.yml
@@ -1,3 +1,7 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
+# NOTE: 'metric_parser' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/redis-multi-example.yml
+++ b/examples/flexConfigs/redis-multi-example.yml
@@ -1,3 +1,7 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
+# NOTE: 'sub_parse' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/redmine-http-example.yml
+++ b/examples/flexConfigs/redmine-http-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'pagination' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # redmine api documentation https://www.redmine.org/projects/redmine/wiki/Rest_api
 ---
 integrations:

--- a/examples/flexConfigs/sqlserver-database-example.yml
+++ b/examples/flexConfigs/sqlserver-database-example.yml
@@ -1,4 +1,4 @@
-# NOTE: 'database' is an experimental function at this time
+# NOTE: 'database' is an experimental API at this time
 # ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:

--- a/examples/flexConfigs/sqlserver-database-example.yml
+++ b/examples/flexConfigs/sqlserver-database-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'database' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/squid-cmd-example.yml
+++ b/examples/flexConfigs/squid-cmd-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'pluck_numbers' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/tomcat-jmx-example.yml
+++ b/examples/flexConfigs/tomcat-jmx-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'metric_parser' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexConfigs/vertica-database-example.yml
+++ b/examples/flexConfigs/vertica-database-example.yml
@@ -1,4 +1,4 @@
-# NOTE: 'database' is an experimental function at this time
+# NOTE: 'database' is an experimental API at this time
 # ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:

--- a/examples/flexConfigs/vertica-database-example.yml
+++ b/examples/flexConfigs/vertica-database-example.yml
@@ -1,3 +1,5 @@
+# NOTE: 'database' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/db.md
 ---
 integrations:
   - name: nri-flex

--- a/examples/flexContainerDiscovery/elasticsearch.yml
+++ b/examples/flexContainerDiscovery/elasticsearch.yml
@@ -1,3 +1,5 @@
+# NOTE: 'sample_keys' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # example label to apply -> flexDiscoveryElastic="t=elasticsearch,c=elasticsearch,tt=img,tm=contains"
 # if using kubernetes add it as a environment variable
 ---

--- a/examples/flexContainerDiscovery/etcd-restApi.yml
+++ b/examples/flexContainerDiscovery/etcd-restApi.yml
@@ -1,3 +1,5 @@
+# NOTE: 'sample_keys' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # example label to apply -> flexDiscoveryEtcd="t=etcd,c=etcd,tt=img,tm=contains"
 # if using kubernetes add it as a environment variable
 ### https://coreos.com/etcd/docs/latest/v2/api.html#statistics

--- a/examples/flexContainerDiscovery/rabbitmq.yml
+++ b/examples/flexContainerDiscovery/rabbitmq.yml
@@ -1,3 +1,5 @@
+# NOTE: 'metric_parser' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # example label to apply -> flexDiscoveryRabbit="t=rabbitmq,c=rabbitmq,tt=img,tm=contains"
 # if using kubernetes add it as a environment variable
 ### https://www.rabbitmq.com/monitoring.html

--- a/examples/flexContainerDiscovery/redis.yml
+++ b/examples/flexContainerDiscovery/redis.yml
@@ -1,3 +1,7 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
+# NOTE: 'metric_parser' and 'sub_parse' are experimental functions at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # example label to apply -> flexDiscoveryRedis="t=redis,c=redis,tt=img,tm=contains"
 # if using kubernetes -> flexDiscoveryRedis:"t_redis.c_redis.tt_img.tm_contains"
 ---

--- a/examples/flexContainerDiscovery/tomcat-jmx.yml
+++ b/examples/flexContainerDiscovery/tomcat-jmx.yml
@@ -1,3 +1,5 @@
+# NOTE: 'metric_parser' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # example label to apply -> flexDiscoveryTomcat="t=tomcat-jmx,c=tomcat-jmx,tt=img,tm=contains"
 # if using kubernetes add it as a environment variable
 ---

--- a/examples/fullConfigExamples/containerDiscovery/flexContainerDiscovery/redis.yml
+++ b/examples/fullConfigExamples/containerDiscovery/flexContainerDiscovery/redis.yml
@@ -1,3 +1,7 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
+# NOTE: 'metric_parser' and 'sub_parse' are experimental functions at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 # example label to apply -> flexDiscoveryRedis="t=redis,c=redis,tt=img,tm=contains"
 # if using kubernetes -> flexDiscoveryRedis:"t_redis.c_redis.tt_img.tm_contains"
 ---

--- a/examples/fullConfigExamples/standard/flexConfigs/redis-cmd-raw-example.yml
+++ b/examples/fullConfigExamples/standard/flexConfigs/redis-cmd-raw-example.yml
@@ -1,3 +1,7 @@
+# NOTE: 'dial' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/dial.md
+# NOTE: 'metric_parser' and 'sub_parse' are experimental functions at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/functions.md
 ---
 name: redisFlex
 apis: 

--- a/examples/lambdaExample/serverless.yml
+++ b/examples/lambdaExample/serverless.yml
@@ -1,3 +1,6 @@
+# NOTE: 'git sync' is an experimental function at this time
+# ref: https://github.com/newrelic/nri-flex/blob/master/docs/experimental/git_sync.md
+---
 service: nri-flex
 
 provider:


### PR DESCRIPTION
adding comments to all example `.yml` files that have functions from the [experimental](https://github.com/newrelic/nri-flex/tree/master/docs/experimental) docs. this is a fix for Issue #178 