### PR TITLE
ci: Enable 32-bit releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,13 @@ builds:
       - darwin
       - windows
     goarch:
+      - 386
       - amd64
       - arm
       - arm64
+    ignore:
+      - goos: darwin
+        goarch: 386
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
Updated [goreleaser](https://goreleaser.com/) to build 32-bit binaries