### PR TITLE
Fixed JMX bug - buildCommand expects command rather than runCommand

### DIFF
--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -86,6 +86,7 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 	runCommand := command.Run
 	if command.Output == load.Jmx {
 		SetJMXCommand(&runCommand, command, api, yml)
+		command.Run = runCommand
 	}
 	commandTimeout := load.DefaultTimeout
 	if api.Timeout > 0 {


### PR DESCRIPTION
The following line broke the jmx command. The jmx command should come from `runCommand` instead of `command.Run`

https://github.com/newrelic/nri-flex/blob/0a41b64210d7c8d10e5c2cf27e6bf17acdc5f1ab/internal/inputs/commands.go#L103