### PR TITLE
Add a mention of JSON to the command API doc

### DIFF
--- a/docs/apis/commands.md
+++ b/docs/apis/commands.md
@@ -1,6 +1,6 @@
 # `commands`
 
-The `commands` API allows you to retrieve information from any application or shell command. It can accept multiple commands executed in sequence, and is platform-agnostic. Keep in mind that platform specific applications differ between different operating systems, and some may not be available (for example, Kubernetes).
+The `commands` API allows you to retrieve information from any application or shell command. It can accept multiple commands executed in sequence, RAW and JSON input format, and is platform-agnostic. Keep in mind that platform specific applications differ between different operating systems, and some may not be available (for example, Kubernetes).
 
 * [Basic usage](#Basicusage)
 * [Configuration properties](#Configurationproperties)


### PR DESCRIPTION
JSON format is supported by the command API but there is no mention of it. 
This is an example using it https://github.com/newrelic/nri-flex/blob/master/examples/flexConfigs/osquery-example.yml