### PR TITLE
Linux process discovery default to false

### DIFF
--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -50,7 +50,7 @@ type ArgumentList struct {
 	EncryptPass          string `default:"" help:"Pass to be encypted"`
 	PassPhrase           string `default:"N3wR3lic!" help:"PassPhrase used to de/encrypt"`
 	DiscoverProcessWin   bool   `default:"false" help:"Discover Process info on Windows OS"`
-	DiscoverProcessLinux bool   `default:"true" help:"Discover Process info on Linux OS"`
+	DiscoverProcessLinux bool   `default:"false" help:"Discover Process info on Linux OS"`
 	NRJMXToolPath        string `default:"/usr/lib/nrjmx/" help:"Set a custom path for nrjmx tool"`
 	StructuredLogs       bool   `default:"false" help:"output logs in Json structure format for external tool parsing"`
 }


### PR DESCRIPTION
This capability is not commonly used anymore.

Disabling it to false will decrease the size of flexStatusSample (important for new pricing model) and provide a performance increase for linux users.

We can consider deprecating the functionality as a second step later.

cc/ @thezackm @ardias 