### PR TITLE
Adding xml format support for commands function

### DIFF
--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	xj "github.com/basgys/goxml2json"
 	"github.com/newrelic/nri-flex/internal/formatter"
 	"github.com/newrelic/nri-flex/internal/load"
 	"github.com/sirupsen/logrus"
@@ -394,20 +393,21 @@ func detectCommandOutput(dataOutput string, commandOutput string) (string, inter
 	// check xml
 	xmlSignature := `<?xml version=`
 	if strings.HasPrefix(strings.TrimSpace(dataOutput), xmlSignature) {
-		xmlBody := strings.NewReader(dataOutput)
-		jsonBody, err := xj.Convert(xmlBody)
+		return load.TypeXML, nil
+		// xmlBody := strings.NewReader(dataOutput)
+		// jsonBody, err := xj.Convert(xmlBody)
 
-		if err != nil {
-			load.Logrus.WithFields(logrus.Fields{
-				"err": err,
-			}).Errorf("Failed to convert XML to Json ")
-		} else {
-			var f interface{}
-			err := json.Unmarshal(jsonBody.Bytes(), &f)
-			if err == nil {
-				return load.TypeXML, f
-			}
-		}
+		// if err != nil {
+		// 	load.Logrus.WithFields(logrus.Fields{
+		// 		"err": err,
+		// 	}).Errorf("Failed to convert XML to Json ")
+		// } else {
+		// 	var f interface{}
+		// 	err := json.Unmarshal(jsonBody.Bytes(), &f)
+		// 	if err == nil {
+		// 		return load.TypeXML, f
+		// 	}
+		// }
 
 	}
 

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	xj "github.com/basgys/goxml2json"
 	"github.com/newrelic/nri-flex/internal/formatter"
 	"github.com/newrelic/nri-flex/internal/load"
 	"github.com/sirupsen/logrus"
@@ -393,21 +394,21 @@ func detectCommandOutput(dataOutput string, commandOutput string) (string, inter
 	// check xml
 	xmlSignature := `<?xml version=`
 	if strings.HasPrefix(strings.TrimSpace(dataOutput), xmlSignature) {
-		return load.TypeXML, nil
-		// xmlBody := strings.NewReader(dataOutput)
-		// jsonBody, err := xj.Convert(xmlBody)
+		// return load.TypeXML, nil
+		xmlBody := strings.NewReader(dataOutput)
+		jsonBody, err := xj.Convert(xmlBody)
 
-		// if err != nil {
-		// 	load.Logrus.WithFields(logrus.Fields{
-		// 		"err": err,
-		// 	}).Errorf("Failed to convert XML to Json ")
-		// } else {
-		// 	var f interface{}
-		// 	err := json.Unmarshal(jsonBody.Bytes(), &f)
-		// 	if err == nil {
-		// 		return load.TypeXML, f
-		// 	}
-		// }
+		if err != nil {
+			load.Logrus.WithFields(logrus.Fields{
+				"err": err,
+			}).Errorf("Failed to convert XML to Json ")
+		} else {
+			var f interface{}
+			err := json.Unmarshal(jsonBody.Bytes(), &f)
+			if err == nil {
+				return load.TypeXML, f
+			}
+		}
 
 	}
 

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -393,7 +393,7 @@ func detectCommandOutput(dataOutput string, commandOutput string) (string, inter
 	}
 	// check xml
 	xmlSignature := `<?xml version=`
-	if strings.HasPrefix(strings.TrimSpace(dataOutput), xmlSignature) {
+	if strings.HasPrefix(strings.TrimSpace(dataOutput), xmlSignature) || commandOutput == load.TypeXML {
 		// return load.TypeXML, nil
 		xmlBody := strings.NewReader(dataOutput)
 		jsonBody, err := xj.Convert(xmlBody)

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	xj "github.com/basgys/goxml2json"
 	"github.com/newrelic/nri-flex/internal/formatter"
 	"github.com/newrelic/nri-flex/internal/load"
 	"github.com/sirupsen/logrus"
@@ -243,6 +244,8 @@ func processOutput(dataStore *[]interface{}, output string, dataSample *map[stri
 		case load.TypeJSON:
 			// load.StoreAppend(dataInterface)
 			*dataStore = append(*dataStore, dataInterface)
+		case load.TypeXML:
+			*dataStore = append(*dataStore, dataInterface)
 		case load.Jmx:
 			*processType = "jmx"
 			ParseJMX(dataStore, dataInterface, command, dataSample)
@@ -391,7 +394,21 @@ func detectCommandOutput(dataOutput string, commandOutput string) (string, inter
 	// check xml
 	xmlSignature := `<?xml version=`
 	if strings.HasPrefix(strings.TrimSpace(dataOutput), xmlSignature) {
-		return load.TypeXML, nil
+		xmlBody := strings.NewReader(dataOutput)
+		jsonBody, err := xj.Convert(xmlBody)
+
+		if err != nil {
+			load.Logrus.WithFields(logrus.Fields{
+				"err": err,
+			}).Errorf("Failed to convert XML to Json ")
+		} else {
+			var f interface{}
+			err := json.Unmarshal(jsonBody.Bytes(), &f)
+			if err == nil {
+				return load.TypeXML, f
+			}
+		}
+
 	}
 
 	// default raw

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -369,7 +369,7 @@ type Command struct {
 	IgnoreOutput     bool              `yaml:"ignore_output"`     // can be useful for chaining commands together
 	MetricParser     MetricParser      `yaml:"metric_parser"`     // not used yet
 	CustomAttributes map[string]string `yaml:"custom_attributes"` // set additional custom attributes
-	Output           string            `yaml:"output"`            // jmx, raw, json
+	Output           string            `yaml:"output"`            // jmx, raw, json,xml
 	LineEnd          int               `yaml:"line_end"`          // stop processing command output after a certain amount of lines
 	LineStart        int               `yaml:"line_start"`        // start from this line
 	Timeout          int               `yaml:"timeout"`           // command timeout


### PR DESCRIPTION
**Adding  xml format support for `commands` function.** 

The file content must have the following signature:

```
<?xml version="1.0"
```

Sample XML file: 
```
<?xml version="1.0" encoding="UTF-8"?>
<catalog>
   <book id="bk101">
      <author>Gambardella, Matthew</author>
      <title>XML Developer's Guide</title>
      <genre>Computer</genre>
      <price>44.95</price>
      <publish_date>2000-10-01</publish_date>
      <description>An in-depth look at creating applications with XML.</description>
   </book>
   <book id="bk102">
      <author>Ralls, Kim</author>
      <title>Midnight Rain</title>
      <genre>Fantasy</genre>
      <price>5.95</price>
      <publish_date>2000-12-16</publish_date>
      <description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
   </book>
</catalog>
```

Sample Flex integration file: 

```
integrations:
  - name: nri-flex
    interval: 30s
    config:
      name: xmlFileExample
      apis:
        - name: xmlFileExample
          commands:
            - run: cat myexamples/simpleXML.xml
              output: xml
```