### PR TITLE
enhanced pagination: added NextLinkHost to complement NextLinkKey

### DIFF
--- a/internal/inputs/http.go
+++ b/internal/inputs/http.go
@@ -313,7 +313,7 @@ func handlePagination(url *string, Pagination *load.Pagination, nextLink *string
 					"err": err,
 				}).Error("http: failed to compact json")
 			} else {
-				if Pagination.PageLimitKey != "" || Pagination.PageNextKey != "" || Pagination.PayloadKey != "" || Pagination.MaxPagesKey != "" || Pagination.NextCursorKey != "" {
+				if Pagination.PageLimitKey != "" || Pagination.PageNextKey != "" || Pagination.PayloadKey != "" || Pagination.MaxPagesKey != "" || Pagination.NextCursorKey != "" || Pagination.NextLinkKey != "" {
 					jsonString := buffer.String()
 					if Pagination.PageLimitKey != "" { // offset
 						matches := paginationRegex(fmt.Sprintf(`"%v":(\d+)|"%v":"(\d+)"`, Pagination.PageLimitKey, Pagination.PageLimitKey), jsonString, nextLink)
@@ -356,9 +356,14 @@ func handlePagination(url *string, Pagination *load.Pagination, nextLink *string
 						}
 					}
 					if Pagination.NextLinkKey != "" {
-						matches := paginationRegex(fmt.Sprintf(`"%v":\"(\S+)\"`, Pagination.NextLinkKey), jsonString, nextLink)
+						matches := paginationRegex(fmt.Sprintf(`"%v":\"(.*?)\"`, Pagination.NextLinkKey), jsonString, nextLink)
 						if len(matches) >= 2 {
-							manualNextLink = matches[1]
+							if len(Pagination.NextLinkHost) > 0 {
+								manualNextLink = Pagination.NextLinkHost + matches[1]
+							} else {
+								manualNextLink = matches[1]
+							}
+
 						}
 					}
 					if Pagination.PayloadKey != "" {

--- a/internal/inputs/http.go
+++ b/internal/inputs/http.go
@@ -313,7 +313,7 @@ func handlePagination(url *string, Pagination *load.Pagination, nextLink *string
 					"err": err,
 				}).Error("http: failed to compact json")
 			} else {
-				if Pagination.PageLimitKey != "" || Pagination.PageNextKey != "" || Pagination.PayloadKey != "" || Pagination.MaxPagesKey != "" || Pagination.NextCursorKey != "" || Pagination.NextLinkKey != "" {
+				{ // if Pagination.PageLimitKey != "" || Pagination.PageNextKey != "" || Pagination.PayloadKey != "" || Pagination.MaxPagesKey != "" || Pagination.NextCursorKey != "" || Pagination.NextLinkKey != "" {
 					jsonString := buffer.String()
 					if Pagination.PageLimitKey != "" { // offset
 						matches := paginationRegex(fmt.Sprintf(`"%v":(\d+)|"%v":"(\d+)"`, Pagination.PageLimitKey, Pagination.PageLimitKey), jsonString, nextLink)

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -419,7 +419,8 @@ type Pagination struct {
 	NextCursorKey string `yaml:"next_cursor_key"` // watch for next cursor to query next
 	MaxCursorKey  string `yaml:"max_cursor_key"`  // watch for max cursor to stop at
 
-	NextLinkKey string `yaml:"next_link_key"` // look for a next link key to browse too
+	NextLinkKey  string `yaml:"next_link_key"`  // look for a next link key to browse too
+	NextLinkHost string `yaml:"next_link_host"` // set next link host - useful when next_link_key returns a partial URL, e.g "/mynextlinkABC", the next link will be {next_link_host}/mynextlinkABC
 }
 
 // RegMatch support for regex matches


### PR DESCRIPTION
**HTTP pagination enhancement**
- Added `next_link_host` to pagination, useful when `next_link_key` does not contain host. 

In the following example,  
- If the  `next_link_key` -> `nextRecordsUrl` returns **/myLink2**
- `next_link_host` is set to _http://example.com_
- The next link built by Flex will be _{next_link_host}_**{next_link_key}**  ->  _http://example.com_**/myLink2**


```JSON
          pagination:
            next_link_key: nextRecordsUrl
            next_link_host: http://example.com
            max_pages: 1000
            payload_key: nextRecordsUrl
```


