### PR TITLE
Replaced err with pingError in debug logging

### DIFF
--- a/internal/inputs/database.go
+++ b/internal/inputs/database.go
@@ -63,7 +63,7 @@ func ProcessQueries(dataStore *[]interface{}, yml *load.Config, apiNo int) {
 
 	if pingError != nil {
 		load.Logrus.WithFields(logrus.Fields{
-			"err":      err,
+			"err":      pingError,
 			"name":     yml.Name,
 			"database": api.Database,
 		}).Debug("database: ping error")


### PR DESCRIPTION
The current output (as observed at a customer) is nil. This is because `if err != nil` is done a couple of lines higher, so this code wouldn't run if err != nil. Replacing err with pingError should return the right information for the customer to debug the error code.

This fixes #239 