### PR TITLE
Added option to hide error_exec output

### DIFF
--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -119,20 +119,20 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 			}
 			*dataStore = append(*dataStore, errorSample)
 			return
-		} else {
-			load.Logrus.WithFields(logrus.Fields{
-				"exec":       command.Run,
-				"err":        err,
-				"suggestion": "if you are handling this error case, ignore",
-			}).Debug("command: failed")
-			errorSample := map[string]interface{}{
-				"error":      err,
-				"error_msg":  string(output),
-				"error_exec": command.Run,
-			}
-			*dataStore = append(*dataStore, errorSample)
-			return
 		}
+		load.Logrus.WithFields(logrus.Fields{
+			"exec":       command.Run,
+			"err":        err,
+			"suggestion": "if you are handling this error case, ignore",
+		}).Debug("command: failed")
+		errorSample := map[string]interface{}{
+			"error":      err,
+			"error_msg":  string(output),
+			"error_exec": command.Run,
+		}
+		*dataStore = append(*dataStore, errorSample)
+		return
+
 	}
 
 	err = ctx.Err()

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -106,18 +106,33 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 	output, err := cmd.CombinedOutput()
 
 	if err != nil {
-		load.Logrus.WithFields(logrus.Fields{
-			"exec":       command.Run,
-			"err":        err,
-			"suggestion": "if you are handling this error case, ignore",
-		}).Debug("command: failed")
-		errorSample := map[string]interface{}{
-			"error":      err,
-			"error_msg":  string(output),
-			"error_exec": command.Run,
+		if command.HideErrorExec {
+			load.Logrus.WithFields(logrus.Fields{
+				"exec":       command.Run,
+				"err":        err,
+				"suggestion": "if you are handling this error case, ignore",
+			}).Debug("command: failed")
+			errorSample := map[string]interface{}{
+				"error":      err,
+				"error_msg":  string(output),
+				"error_exec": "COMMAND HIDDEN!",
+			}
+			*dataStore = append(*dataStore, errorSample)
+			return
+		} else {
+			load.Logrus.WithFields(logrus.Fields{
+				"exec":       command.Run,
+				"err":        err,
+				"suggestion": "if you are handling this error case, ignore",
+			}).Debug("command: failed")
+			errorSample := map[string]interface{}{
+				"error":      err,
+				"error_msg":  string(output),
+				"error_exec": command.Run,
+			}
+			*dataStore = append(*dataStore, errorSample)
+			return
 		}
-		*dataStore = append(*dataStore, errorSample)
-		return
 	}
 
 	err = ctx.Err()

--- a/internal/load/README.md
+++ b/internal/load/README.md
@@ -480,6 +480,10 @@ type Command struct {
 
 	// RegexMatches
 	RegexMatches []RegMatch `yaml:"regex_matches"`
+
+	// Hide exec command from output
+	HideErrorExec bool `yaml:"hide_error_exec"` // prevent executable command from getting displayed when there is an error
+
 }
 ```
 

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -394,6 +394,9 @@ type Command struct {
 
 	// RegexMatches
 	RegexMatches []RegMatch `yaml:"regex_matches"`
+
+	// Mask run command
+	HideErrorExec bool `yaml:"hide_error_exec"` // prevent executable command from getting displayed when there is an error
 }
 
 // Pagination handles request pagination


### PR DESCRIPTION
Option to hide commands from getting displayed in `error_exec` when set to true output records  COMMAND HIDDEN!

````
integrations:
  - name: nri-flex
    config:
      name: curlFlex
      apis:
        - name: curl
          commands:
            - run: curl -w  -o /dev/null -s https://google.com
              hide_error_exec: true