### PR TITLE
feat: apply custom variables passed through FLEX_META

### DIFF
--- a/docs/basics/configure.md
+++ b/docs/basics/configure.md
@@ -4,21 +4,21 @@ Flex integrations are code-less: They only require that you write configuration 
 
 Configurations can [go embedded](#AddyourFlexconfigurationtointegrations.d) in the Infrastructure agent configuration file, or live as stand-alone config files that you can test separately and [link](#Linktoaseparateconfigurationfile) from the main integrations config file. What approach to follow is up to you.
 
-* [Add your Flex configuration to `integrations.d`](#AddyourFlexconfigurationtointegrations.d)
-* [Link to a separate configuration file](#Linktoaseparateconfigurationfile)
-* [Configuration schema](#Configurationschema)
-* [Configuration example](#Configurationexample)
+- [Add your Flex configuration to `integrations.d`](#AddyourFlexconfigurationtointegrations.d)
+- [Link to a separate configuration file](#Linktoaseparateconfigurationfile)
+- [Configuration schema](#Configurationschema)
+- [Configuration example](#Configurationexample)
 
 ## <a name='AddyourFlexconfigurationtointegrations.d'></a>Add your configuration to `integrations.d`
 
 Since it comes bundled with the Infrastructure agent, Flex's configuration must be stored as YAML in the same folder as the rest of [on-host integrations](https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180):
 
-* Linux: `/etc/newrelic-infra/integrations.d`
-* Windows: `C:\Program Files\New Relic\newrelic-infra\integrations.d\`
+- Linux: `/etc/newrelic-infra/integrations.d`
+- Windows: `C:\Program Files\New Relic\newrelic-infra\integrations.d\`
 
 The main section of the integrations config file is used by the Infrastructure agent to execute Flex like any other integration; you can add your Flex configuration under `config`.
 
-For example, `/etc/newrelic-infra/integrations.d/my-flex-config.yml`  could contain the following:
+For example, `/etc/newrelic-infra/integrations.d/my-flex-config.yml` could contain the following:
 
 ```yaml
 integrations:
@@ -32,8 +32,8 @@ integrations:
           url: https://my-host:8443/admin/metrics.json
 ```
 
-* **On-Host Integration Configuration**: the first five lines are read by the agent to execute the `nri-flex` binary every 60 seconds, canceling the execution if it lasts more than 5 seconds. Refer to [Integration configuration file specifications](https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180) for more details about the contents of the on-host integrations configuration file.
-* **Flex configuration**: contains the actions to be taken using data sources APIs, such as the [url](../apis/url.md) API.
+- **On-Host Integration Configuration**: the first five lines are read by the agent to execute the `nri-flex` binary every 60 seconds, canceling the execution if it lasts more than 5 seconds. Refer to [Integration configuration file specifications](https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180) for more details about the contents of the on-host integrations configuration file.
+- **Flex configuration**: contains the actions to be taken using data sources APIs, such as the [url](../apis/url.md) API.
 
 > To get a quick, first picture of a Flex configuration file, you can start following our [basic, step-by-step tutorial](../../basic-tutorial.md) or check existing config files under [/examples](../../examples).
 
@@ -59,6 +59,7 @@ apis:
   - event_type: ExampleSample
     url: https://my-host:8443/admin/metrics.json
 ```
+
 ## <a name='Configurationschema'></a>Configuration schema
 
 The following schema describes the overall structure of a Flex configuration.
@@ -70,7 +71,7 @@ The following schema describes the overall structure of a Flex configuration.
 | +--------------+     |
 | | <properties> |     |   Suffixes:
 | +--------------|     |       ? optional
-| custom_attributes?   |       * multiple repetitions 
+| custom_attributes?   |       * multiple repetitions
 | +----------------+   |
 | | <key>: <value> | * |
 | +----------------+   |
@@ -105,29 +106,29 @@ global:
 
 These are all the possible `global` properties:
 
-| Property | Description |
-|---|---|
-| `base_url` | Base URL. See [specifying a common base URL](../apis/url.md#specifying-a-common-base-url-with-base_url) |
-| `user` | Username for APIs that require user and password authentication |
-| `password` | Password for APIs that require user and password authentication |
-| `pass_phrase` | Pass phrase for encrypte `password` properties  |
-| `proxy` | Proxy URL for APIs whose connections require it |
-| `timeout` | Timeout for the API connections, in milliseconds |
-| `headers` | Key-value map of headers for the HTTP/HTTPS connections |
-| `tls_config` | TLS configuration. See [configuring your HTTPS connections](../apis/url.md#configuring-your-https-connections-with-tls_config) |
-| `ssh_pem_file` | Path to PEM file to enable SSH authentication |  
-| `JMX` | See [JMX](../experimental/jmx.md) (experimental) |
+| Property       | Description                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `base_url`     | Base URL. See [specifying a common base URL](../apis/url.md#specifying-a-common-base-url-with-base_url)                        |
+| `user`         | Username for APIs that require user and password authentication                                                                |
+| `password`     | Password for APIs that require user and password authentication                                                                |
+| `pass_phrase`  | Pass phrase for encrypte `password` properties                                                                                 |
+| `proxy`        | Proxy URL for APIs whose connections require it                                                                                |
+| `timeout`      | Timeout for the API connections, in milliseconds                                                                               |
+| `headers`      | Key-value map of headers for the HTTP/HTTPS connections                                                                        |
+| `tls_config`   | TLS configuration. See [configuring your HTTPS connections](../apis/url.md#configuring-your-https-connections-with-tls_config) |
+| `ssh_pem_file` | Path to PEM file to enable SSH authentication                                                                                  |
+| `JMX`          | See [JMX](../experimental/jmx.md) (experimental)                                                                               |
 
 ### <a name='apis'></a>apis
 
 The `apis` section allows you to define multiple entries for data acquisition and processing. Each entry must have a `name` or `event_type`, which is used to name the event type in New Relic:
 
-* `event_type` provides a name for each sample, which is used as table name for querying the metrics
+- `event_type` provides a name for each sample, which is used as table name for querying the metrics
   in the New Relic UI. `event_type` usually have names like `MySQLSample`, `MyRemoteSample`, `FolderSample`, etc.
-* If `event_type` is not defined and `name` is, the submitted event type is `name`
+- If `event_type` is not defined and `name` is, the submitted event type is `name`
   with the `Sample` prefix concatenated.
-    - For example, `name: FolderSize` would make Flex to create events named `event_type: FolderSizeSample`.
-* Each `event_type` is automatically decorated by the infrastructure agent with a `timestamp` attribute.
+  - For example, `name: FolderSize` would make Flex to create events named `event_type: FolderSizeSample`.
+- Each `event_type` is automatically decorated by the infrastructure agent with a `timestamp` attribute.
   Flex can overwrite this attribute, but it's not recommended as it can impact the alerts configured for this `event_type`.
 
 In addition to the fields that define the name of the sample, each `apis` entry requires the type of API to parse data from, and, optionally, a list of [functions](../basics/functions.md) for processing the data coming from the API.
@@ -140,17 +141,17 @@ For example, consider a service that returns the following payload
 
 ```json
 {
-    "id": "eca0338f4ea31566",
-    "leaderInfo": {
-        "leader": "8a69d5f6b7814500",
-        "startTime": "2014-10-24T13:15:51.186620747-07:00",
-        "uptime": "10m59.322358947s",
-        "abc": {
-            "def": 123,
-            "hij": 234
-        }
-    },
-    "name": "node3"
+  "id": "eca0338f4ea31566",
+  "leaderInfo": {
+    "leader": "8a69d5f6b7814500",
+    "startTime": "2014-10-24T13:15:51.186620747-07:00",
+    "uptime": "10m59.322358947s",
+    "abc": {
+      "def": 123,
+      "hij": 234
+    }
+  },
+  "name": "node3"
 }
 ```
 
@@ -159,8 +160,8 @@ as a result of executing the following `url` API:
 ```yaml
 name: example
 apis:
-    - name: someService
-      url: http://some-service.com/status
+  - name: someService
+    url: http://some-service.com/status
 ```
 
 As we want to process it in another API, we use the `cache` function. Note that the cache `key` is the URL because it's an `url` API:
@@ -168,13 +169,13 @@ As we want to process it in another API, we use the `cache` function. Note that 
 ```yaml
 name: example
 apis:
-    - name: status
-      url: http://some-service.com/status
-    - name: otherStatus
-      cache: http://some-service.com/status
-      strip_keys:
-          - id
-          - name
+  - name: status
+    url: http://some-service.com/status
+  - name: otherStatus
+    cache: http://some-service.com/status
+    strip_keys:
+      - id
+      - name
 ```
 
 With a `commands` API, you should use the name of the API instead:
@@ -182,16 +183,16 @@ With a `commands` API, you should use the name of the API instead:
 ```yaml
 name: example
 apis:
-    - name: status
-      commands:
-          # assume that this file contains the same json payload showed above the beginning
-          - run: cat /var/some/file
-    - name: otherStatus
-      cache: status
-      strip_keys:
-          - id
-          - name
-``` 
+  - name: status
+    commands:
+      # assume that this file contains the same json payload showed above the beginning
+      - run: cat /var/some/file
+  - name: otherStatus
+    cache: status
+    strip_keys:
+      - id
+      - name
+```
 
 ### <a name='Customattributes'></a>Custom attributes
 
@@ -201,10 +202,11 @@ With Flex you can add your own custom attributes to samples. Add any custom attr
 custom_attributes:
   greeting: hello
 ```
-Custom attributes can be defined nearly anywhere in your configuration. For example, under `global`, or `api`, or further nested under each command. 
+
+Custom attributes can be defined nearly anywhere in your configuration. For example, under `global`, or `api`, or further nested under each command.
 Attributes defined at the lowest level take precedence.
 
-Custom attributes defined at the `global` level are added to all samples, while custom attributes defined at the API level are added only at the level of the API where they are defined. 
+Custom attributes defined at the `global` level are added to all samples, while custom attributes defined at the API level are added only at the level of the API where they are defined.
 
 ### <a name='Environmentvariables'></a>Environment variables
 
@@ -215,17 +217,23 @@ You can inject values for environment variables anywhere in a Flex config file. 
 Here's an example of a Flex configuration embedded in the main integrations configuration file:
 
 ```yaml
-integrations:                                    # OHI configuration starts here  
-  - name: nri-flex                               # OHI to be executed by the Agent
-    config:                                      # OHI configuration to be parsed by Flex
+integrations: # OHI configuration starts here
+  - name: nri-flex # OHI to be executed by the Agent
+    config: # OHI configuration to be parsed by Flex
       # Actual Flex configuration starts here
-      name: linuxDirectorySize                   # Flex configuration name
-      apis:                                       
-        - name: DirectorySize                    # Event type will be DirectorySizeSample
-          commands:                              # Selecting the API `commands`
-            - run: du -c $$DIR                   # Running a shell command
-              split: horizontal                  # Post-processing function: split horizontally
-              set_header: [dirSizeBytes,dirName] # Names for the headers of the table resulting from split
-              regex_match: true                  # Splits horizontally matching a regular expression
-              split_by: (\d+)\s+(.*)             # Captures the regexpes between parentheses as the headers above   
+      name: linuxDirectorySize # Flex configuration name
+      apis:
+        - name: DirectorySize # Event type will be DirectorySizeSample
+          commands: # Selecting the API `commands`
+            - run: du -c $$DIR # Running a shell command
+              split: horizontal # Post-processing function: split horizontally
+              set_header: [dirSizeBytes, dirName] # Names for the headers of the table resulting from split
+              regex_match: true # Splits horizontally matching a regular expression
+              split_by: (\d+)\s+(.*) # Captures the regexpes between parentheses as the headers above
 ```
+
+### <a name='specialenvs'></a>Special environment variables
+
+- `FLEX_META` - setting this environment variable with a flat JSON payload will unpack this into global custom attributes.
+- `FLEX_CMD_PREPEND` - automatically prepend to commands being run.
+- `FLEX_CMD_APPEND` - automatically append to a commands being run.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,3 +163,15 @@ func TestSubEnvVariables(t *testing.T) {
 		t.Errorf("failed to sub all variables %v", str)
 	}
 }
+
+func TestApplyFlexMeta(t *testing.T) {
+	os.Setenv("FLEX_META", "{\"abc\":\"def\",\"hello\":123}")
+	config := load.Config{}
+	applyFlexMeta(&config)
+
+	if config.CustomAttributes["abc"] != "def" {
+		t.Errorf("failed to apply flex meta variable abc expected %v got %v", "def", config.CustomAttributes["hello"])
+	} else if config.CustomAttributes["hello"] != "123" {
+		t.Errorf("failed to apply flex meta variable hello expected %v got %v", "123", config.CustomAttributes["hello"])
+	}
+}

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -8,6 +8,7 @@ package inputs
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -84,6 +85,7 @@ func RunCommands(dataStore *[]interface{}, yml *load.Config, apiNo int) {
 }
 
 func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command, api load.API, startTime int64, dataSample map[string]interface{}, processType string) {
+	command.Run = os.Getenv("FLEX_CMD_PREPEND") + command.Run + os.Getenv("FLEX_CMD_APPEND")
 	runCommand := command.Run
 	if command.Output == load.Jmx {
 		SetJMXCommand(&runCommand, command, api, yml)


### PR DESCRIPTION
When FLEX_META environment variable is defined. Eg. `FLEX_META='{"hello":"abc"}'` the json payload is unpacked and attached to global custom attributes. 

FLEX_CMD_PREPEND & FLEX_CMD_APPEND to prepend and append to the command. This will be heavily used with the agents discovery mechanism and provide seamless compatibility to existing Flex configs.