### PR TITLE
feat: explicit flag to allow command envs & additional logging

### DIFF
--- a/docs/basics/configure.md
+++ b/docs/basics/configure.md
@@ -235,5 +235,5 @@ integrations: # OHI configuration starts here
 ### <a name='specialenvs'></a>Special environment variables
 
 - `FLEX_META` - setting this environment variable with a flat JSON payload will unpack this into global custom attributes.
-- `FLEX_CMD_PREPEND` - automatically prepend to commands being run.
-- `FLEX_CMD_APPEND` - automatically append to a commands being run.
+- `FLEX_CMD_PREPEND` - automatically prepend to commands being run (Requires AllowEnvCommands enabled).
+- `FLEX_CMD_APPEND` - automatically append to a commands being run (Requires AllowEnvCommands enabled).

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -85,7 +85,7 @@ func RunCommands(dataStore *[]interface{}, yml *load.Config, apiNo int) {
 }
 
 func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command, api load.API, startTime int64, dataSample map[string]interface{}, processType string) {
-	command.Run = os.Getenv("FLEX_CMD_PREPEND") + command.Run + os.Getenv("FLEX_CMD_APPEND")
+	command.Run = envCommandCheck(command.Run)
 	runCommand := command.Run
 	if command.Output == load.Jmx {
 		SetJMXCommand(&runCommand, command, api, yml)
@@ -161,6 +161,19 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 			processOutput(dataStore, string(output), &dataSample, command, api, &processType)
 		}
 	}
+}
+
+// checks if explicitedly enabled log
+func envCommandCheck(commandStr string) string {
+	if load.Args.AllowEnvCommands {
+		load.Logrus.WithFields(logrus.Fields{
+			"command": commandStr,
+			"prepend": os.Getenv("FLEX_CMD_PREPEND"),
+			"append":  os.Getenv("FLEX_CMD_APPEND"),
+		}).Info("command: environment modification enabled")
+		return os.Getenv("FLEX_CMD_PREPEND") + commandStr + os.Getenv("FLEX_CMD_APPEND")
+	}
+	return commandStr
 }
 
 func splitOutput(dataStore *[]interface{}, output string, command load.Command, startTime int64) {

--- a/internal/inputs/commands_test.go
+++ b/internal/inputs/commands_test.go
@@ -6,6 +6,7 @@
 package inputs
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -221,4 +222,22 @@ func TestDf2(t *testing.T) {
 		actualValue := actual[key]
 		assert.Equal(t, expectedValue, actualValue)
 	}
+}
+
+func TestEnvCommandCheck(t *testing.T) {
+	load.Refresh()
+
+	os.Setenv("FLEX_CMD_PREPEND", "echo hi && ")
+
+	command := "echo hello"
+	command = envCommandCheck(command)
+
+	// should not be modified
+	assert.Equal(t, "echo hello", command)
+
+	// should now be modified
+	load.Args.AllowEnvCommands = true
+	command = envCommandCheck(command)
+	assert.Equal(t, "echo hi && echo hello", command)
+
 }

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -53,6 +53,7 @@ type ArgumentList struct {
 	DiscoverProcessLinux bool   `default:"false" help:"Discover Process info on Linux OS"`
 	NRJMXToolPath        string `default:"/usr/lib/nrjmx/" help:"Set a custom path for nrjmx tool"`
 	StructuredLogs       bool   `default:"false" help:"output logs in Json structure format for external tool parsing"`
+	AllowEnvCommands     bool   `default:"false" help:"enable to allow the use of FLEX_CMD_PREPEND & FLEX_CMD_APPEND"`
 }
 
 // Args Infrastructure SDK Arguments List


### PR DESCRIPTION
Additional validation and logging for the use of `FLEX_CMD_PREPEND` & `FLEX_CMD_APPEND`.

AllowEnvCommands is required to be enabled before the use of the above envs.
When enabled the modifications are then allowed and logged at info level by default.

eg output.
```
INFO[0000] command: environment modification enabled     append=<some_value> command="echo hello::bye" prepend=<some_value>
```