### PR TITLE
Kav/command improvements

### DIFF
--- a/docs/apis/commands.md
+++ b/docs/apis/commands.md
@@ -250,9 +250,9 @@ Note both options use regex.
 integrations:
   - name: nri-flex
     config:
-      name: VodafoneSpeedtestIntegration
+      name: SomeIntegration
       apis:
-        - event_type: VodafoneSpeedSample
+        - event_type: SomeSample
           commands:
             - run: "echo hi:bye"
               split_by: ":"
@@ -265,9 +265,9 @@ integrations:
 integrations:
   - name: nri-flex
     config:
-      name: VodafoneSpeedtestIntegration
+      name: SomeIntegration
       apis:
-        - event_type: VodafoneSpeedSample
+        - event_type: SomeSample
           commands:
             - run: "echo hi:bye"
               split_by: ":"
@@ -280,9 +280,9 @@ integrations:
 integrations:
   - name: nri-flex
     config:
-      name: VodafoneSpeedtestIntegration
+      name: SomeIntegration
       apis:
-        - event_type: VodafoneSpeedSample
+        - event_type: SomeSample
           commands:
             - run: "echo hi:bye"
               split_by: ":"

--- a/docs/apis/commands.md
+++ b/docs/apis/commands.md
@@ -2,11 +2,11 @@
 
 The `commands` API allows you to retrieve information from any application or shell command. It can accept multiple commands executed in sequence, raw text, and JSON data, and is platform-agnostic. Keep in mind that platform specific applications differ between different operating systems, and some may not be available (for example, Kubernetes).
 
-* [Basic usage](#Basicusage)
-* [Configuration properties](#Configurationproperties)
-* [Advanced usage](#Advancedusage)
+- [Basic usage](#Basicusage)
+- [Configuration properties](#Configurationproperties)
+- [Advanced usage](#Advancedusage)
 
-##  <a name='Basicusage'></a>Basic usage
+## <a name='Basicusage'></a>Basic usage
 
 ### Linux example
 
@@ -17,7 +17,7 @@ apis:
     commands:
       - run: du -c /somedir
         split: horizontal
-        set_header: [dirSizeBytes,dirName]
+        set_header: [dirSizeBytes, dirName]
         regex_match: true
         split_by: (\d+)\s+(.*)
 ```
@@ -26,7 +26,7 @@ This Linux configuration retrieves the raw output provided by the command define
 
 ### Windows example
 
- A Windows configuration would follow the exact same structure:
+A Windows configuration would follow the exact same structure:
 
 ```yaml
 name: winSvc
@@ -40,32 +40,33 @@ apis:
         row_header: 1
 ```
 
-##  <a name='Configurationproperties'></a>Configuration properties
+## <a name='Configurationproperties'></a>Configuration properties
 
 The following table describes the properties of the `commands` API, which accepts a list of commands, each requiring a `run` directive.
 
-| Name | Type | Default | Description |
-|---:|:---:|:---:|---|
-| `run` | string |  | Command or application that you want to run. It accepts any valid shell command. You can also use environment variables with the format `$$ENV_VAR_NAME` |
-| `shell` | string | `/bin/sh` (Linux) `cmd` (Windows) | Shell to use when executing the command defined in `run`. All native Linux shells, Windows CMD, and Windows PowerShell v1-5.x (`powershell`) and v6+ (`pwsh`) are supported. |
-| `split`| string | `vertical` | Mode of processing of the command output, either vertical with one value per line, or horizontal with more than one value per line (table format). Only used when `ignore_output` is false |
-| `split_by` | string | | Regular expression used to split metric data. It can accept a list of expressions when `sub_parse` is enabled |
-| `regex_match` | string | | Whether the regular expression defined in `split_by` should be interpreted as a match expression (`true`) or as a split expression (`false`) |  
-| `row_header` | int | `0` | Line that contains the header. Only applies if the value is not equal to `row_header` and is greater than or equal to `1` |
-| `row_start` | int | `0` | Line number where Flex starts processing metric data. If `split` is set to `horizontal`, `row_start` is only used if `row_start` is not equal to `row_header` and `row_start` is greater than or equal to `1`|
-| `line_start` | int | `0` | Line number where Flex will start processing data. If `split` is set to `horizontal` and `row_start` is defined, `line_start` will only be used if `line_start` is not equal to `row_header` and `line_start` is greater than or equal to `1`. If both `row_start` and `line_start` are defined, `line_start` takes precedence |
-| `line_end` | int | `0` | Line number (exclusive) at which Flex stops processing data. Only applies if `split` is not equal to `horizontal`|
-| `set_header` | array of strings | `[]` | Name and number of columns Flex should extract data from. Only applies if `split` is equal to `horizontal` |
-| `header_regex_match` | bool | `false` | Whether the regular expression in `header_split_by` should be interpreted as a match expression (`true`) or as a split expression (`false`). Applies only if `split` is equal to `horizontal` |
-| `header_split_by` | string | | Regular expression applied to the header line. Applies only if `split` is equal to `horizontal` |
-| `split_output` | string | | Regular expression used to split the output into blocks of data |
-| `timeout` | int | `10000` | Time to wait, in milliseconds, for the command to execute. If the command takes longer than `timeout`, Flex ignores the output and returns an error. Note that Flex waits for the command to stop by itself| 
+|                 Name |       Type       |              Default              | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------: | :--------------: | :-------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- |
+|                `run` |      string      |                                   | Command or application that you want to run. It accepts any valid shell command. You can also use environment variables with the format `$$ENV_VAR_NAME`                                                                                                                                                                       |
+|              `shell` |      string      | `/bin/sh` (Linux) `cmd` (Windows) | Shell to use when executing the command defined in `run`. All native Linux shells, Windows CMD, and Windows PowerShell v1-5.x (`powershell`) and v6+ (`pwsh`) are supported.                                                                                                                                                   |
+|              `split` |      string      |            `vertical`             | Mode of processing of the command output, either vertical with one value per line, or horizontal with more than one value per line (table format). Only used when `ignore_output` is false                                                                                                                                     |
+|           `split_by` |      string      |                                   | Regular expression used to split metric data. It can accept a list of expressions when `sub_parse` is enabled                                                                                                                                                                                                                  |
+|        `regex_match` |      string      |                                   | Whether the regular expression defined in `split_by` should be interpreted as a match expression (`true`) or as a split expression (`false`)                                                                                                                                                                                   |
+|         `row_header` |       int        |                `0`                | Line that contains the header. Only applies if the value is not equal to `row_header` and is greater than or equal to `1`                                                                                                                                                                                                      |
+|          `row_start` |       int        |                `0`                | Line number where Flex starts processing metric data. If `split` is set to `horizontal`, `row_start` is only used if `row_start` is not equal to `row_header` and `row_start` is greater than or equal to `1`                                                                                                                  |
+|         `line_start` |       int        |                `0`                | Line number where Flex will start processing data. If `split` is set to `horizontal` and `row_start` is defined, `line_start` will only be used if `line_start` is not equal to `row_header` and `line_start` is greater than or equal to `1`. If both `row_start` and `line_start` are defined, `line_start` takes precedence |
+|           `line_end` |       int        |                `0`                | Line number (exclusive) at which Flex stops processing data. Only applies if `split` is not equal to `horizontal`                                                                                                                                                                                                              |
+|         `set_header` | array of strings |               `[]`                | Name and number of columns Flex should extract data from. Only applies if `split` is equal to `horizontal`                                                                                                                                                                                                                     |
+| `header_regex_match` |       bool       |              `false`              | Whether the regular expression in `header_split_by` should be interpreted as a match expression (`true`) or as a split expression (`false`). Applies only if `split` is equal to `horizontal`                                                                                                                                  |
+|    `header_split_by` |      string      |                                   | Regular expression applied to the header line. Applies only if `split` is equal to `horizontal`                                                                                                                                                                                                                                |
+|       `split_output` |      string      |                                   | Regular expression used to split the output into blocks of data                                                                                                                                                                                                                                                                |
+|            `timeout` |       int        |              `10000`              | Time to wait, in milliseconds, for the command to execute. If the command takes longer than `timeout`, Flex ignores the output and returns an error. Note that Flex waits for the command to stop by itself                                                                                                                    |     |
+|             `assert` |       map        |                                   | [Check if command output matches or not matches your assertion string](#Assert-output-exists-before-processing)                                                                                                                                                                                                                |
 
-##  <a name='Advancedusage'></a>Advanced usage
+## <a name='Advancedusage'></a>Advanced usage
 
 The `commands` API accepts additional format directives to better parse the output.
 
-###  <a name='Rawdataparsing'></a>Raw data parsing
+### <a name='Rawdataparsing'></a>Raw data parsing
 
 In the example below, the output from the `df` command is treated as a table with a header. We instruct Flex to extract values using a regex split expression; in this particular case, the regex expression tells Flex that the values are separated by spaces. Value are then assigned in order of appearance to the corresponding keys.
 
@@ -77,7 +78,8 @@ apis:
     commands:
       - run: df -T
         split: horizontal
-        set_header: [fs,fsType,blocks,usedBytes,availableBytes,usedPerc,mountedOn]
+        set_header:
+          [fs, fsType, blocks, usedBytes, availableBytes, usedPerc, mountedOn]
         row_start: 1
         split_by: \s+
 ```
@@ -99,7 +101,7 @@ apis:
 
 To extract the values we use a regex expression in `split_by`. Note that in this case we extract the names of the metric attributes from raw data, so we must be sure that those are correct.
 
-###  <a name='Specifytheshell'></a>Specify the shell
+### <a name='Specifytheshell'></a>Specify the shell
 
 All commands are executed using `/bin/sh` (Linux) or `cmd` (Windows). If you want to use a different shell, you can specify it at API level for all commands, or at command level, which overrides values set at the API level.
 
@@ -134,7 +136,7 @@ apis:
         shell: powershell
         event_type: WindowsCommand
         split: horizontal
-        set_header: [status,name,displayname]
+        set_header: [status, name, displayname]
         row_start: 1
         regex_match: true
         split_by: (\w+)\s+(\w+)\s+(\w+)
@@ -142,7 +144,7 @@ apis:
 
 In this example we are executing a command, `Get-Service`, using PowerShell as the command shell.
 
-###  <a name='Specifyatimeout'></a>Specify a timeout
+### <a name='Specifyatimeout'></a>Specify a timeout
 
 Flex defines a 10 second timeout for each command by default. If the command does not complete within the timeout period, Flex stops processing the current command and moves to the next. You can change the timeout at both API and command levels. Timeout values are specified in milliseconds (for example, 15 seconds are specified as `15000`).
 
@@ -159,7 +161,7 @@ apis:
         name: doesNotTimeout
       - run: sleep 10
         name: alsoDoesNotTimeout
-        timeout: 15000        
+        timeout: 15000
 ```
 
 In the example above we declare three commands. The timeout value of `5000` declared at the API level applies to all commands except `alsoDoesNotTimeout`, which has its own `timeout` statement. Note that Flex will return an error for the first command:
@@ -168,7 +170,7 @@ In the example above we declare three commands. The timeout value of `5000` decl
 command: timed out err="context deadline exceeded" exec="sleep 10"`)
 ```
 
-###  <a name='Splittheoutput'></a>Split the output
+### <a name='Splittheoutput'></a>Split the output
 
 In case the output of the command is not a sequential list of lines/values, use `split_output` to separate results into blocks that are to be processed sequentially. The directive accepts a regex expression for splitting the output into blocks. You can either use a list of regex expressions to extract data from each block, or try raw processing using `split_by`:
 
@@ -195,20 +197,21 @@ other_key:otherValue
 The `split_output` command as defined above gets two blocks of data to which Flex then applies the `regex_matches` expressions for extracting the values. This example results in two metric samples:
 
 ```json
-[{
-  "event_type": "splitOutputSample",
-  "integration_name": "com.newrelic.nri-flex",
-  "value": "value"
-},
-{
-  "event_type": "splitOutputSample",
-  "integration_name": "com.newrelic.nri-flex",
-  "value": "otherValue"
-}]
-
+[
+  {
+    "event_type": "splitOutputSample",
+    "integration_name": "com.newrelic.nri-flex",
+    "value": "value"
+  },
+  {
+    "event_type": "splitOutputSample",
+    "integration_name": "com.newrelic.nri-flex",
+    "value": "otherValue"
+  }
+]
 ```
 
-###  <a name='Manuallyspecifyblocksofdatatoprocess'></a>Manually specify blocks of data to process
+### <a name='Manuallyspecifyblocksofdatatoprocess'></a>Manually specify blocks of data to process
 
 If you know at which line the relevant data starts and where it ends, you can use `line_start` and `line_end` (optional) to limit the data processing to a specific number of lines from the output.
 
@@ -236,3 +239,54 @@ apis:
 ```
 
 Note that `line_end` is exclusive, meaning that you have to add `1` (`0` indexed) to the actual line you want to stop being processed.
+
+### Assert output exists before processing
+
+Add an assert block with a nested variable of `match` and/or `not_match`.
+Note both options use regex.
+
+```yml
+#### Command output must contain the string "hi" - this will continue
+integrations:
+  - name: nri-flex
+    config:
+      name: VodafoneSpeedtestIntegration
+      apis:
+        - event_type: VodafoneSpeedSample
+          commands:
+            - run: "echo hi:bye"
+              split_by: ":"
+              assert:
+                match: hi #### <--------
+```
+
+```yml
+#### Command output must contain the string "foo" - this will NOT continue!
+integrations:
+  - name: nri-flex
+    config:
+      name: VodafoneSpeedtestIntegration
+      apis:
+        - event_type: VodafoneSpeedSample
+          commands:
+            - run: "echo hi:bye"
+              split_by: ":"
+              assert:
+                match: foo #### <--------
+```
+
+```yml
+#### Command output must contain the string "hi" and not contain the string "foo - this will continue
+integrations:
+  - name: nri-flex
+    config:
+      name: VodafoneSpeedtestIntegration
+      apis:
+        - event_type: VodafoneSpeedSample
+          commands:
+            - run: "echo hi:bye"
+              split_by: ":"
+              assert:
+                match: hi ##### <------------
+                not_match: foo #### <--------
+```

--- a/docs/basics/configure.md
+++ b/docs/basics/configure.md
@@ -237,3 +237,4 @@ integrations: # OHI configuration starts here
 - `FLEX_META` - setting this environment variable with a flat JSON payload will unpack this into global custom attributes.
 - `FLEX_CMD_PREPEND` - automatically prepend to commands being run (Requires AllowEnvCommands enabled).
 - `FLEX_CMD_APPEND` - automatically append to a commands being run (Requires AllowEnvCommands enabled).
+- `FLEX_CMD_WRAP` - automatically wrap the command in quotes (Requires AllowEnvCommands enabled).

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -504,7 +504,11 @@ func buildCommand(ctx context.Context, api load.API, command load.Command) *exec
 	return exec.CommandContext(ctx, commandShell, secondParameter, command.Run)
 }
 
-// checkAssertion check the assertion
+// checkAssertion perform output based assertions
+// when a match or not_match value is defined in the command section an assertion will be performed
+// if only match is defined, and the output successfully matches it will continue
+// if only not_match is defined, and the output successfully does not contain the output it will continue
+// if both match and not_match is defined, both the above must be true to continue
 func checkAssertion(assert load.Assert, output []byte) bool {
 
 	// return true if no matches defined

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -8,6 +8,7 @@ package inputs
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -105,7 +106,29 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 
 	// Create the command with our context
 	cmd := buildCommand(ctx, api, command)
+
+	// https://golang.org/pkg/os/exec/#Cmd.StdinPipe
+	if load.Args.StdinPipe {
+		_, err := cmd.StdinPipe()
+		if err != nil {
+			load.Logrus.WithFields(logrus.Fields{
+				"exec":       command.Run,
+				"err":        err,
+				"suggestion": "StdinPipe failed",
+			}).Debug("command: failed")
+		}
+	}
+
 	output, err := cmd.CombinedOutput()
+
+	// check assertion, if the result is false return immediately
+	if !checkAssertion(command.Assert, output) {
+		load.Logrus.WithFields(logrus.Fields{
+			"name": yml.Name,
+			"exe":  command.Run,
+		}).Debug("commands: assertion failed will not process")
+		return
+	}
 
 	if err != nil {
 		if command.HideErrorExec {
@@ -134,7 +157,6 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 		}
 		*dataStore = append(*dataStore, errorSample)
 		return
-
 	}
 
 	err = ctx.Err()
@@ -171,6 +193,18 @@ func envCommandCheck(commandStr string) string {
 			"prepend": os.Getenv("FLEX_CMD_PREPEND"),
 			"append":  os.Getenv("FLEX_CMD_APPEND"),
 		}).Info("command: environment modification enabled")
+
+		switch os.Getenv("FLEX_CMD_WRAP") {
+		case "\"":
+			commandStr = fmt.Sprintf("\"%v\"", commandStr)
+		case "'":
+			commandStr = fmt.Sprintf("'%v'", commandStr)
+		case "`":
+			commandStr = fmt.Sprintf("`%v`", commandStr)
+		case "true":
+			commandStr = fmt.Sprintf("\"%v\"", commandStr)
+		}
+
 		return os.Getenv("FLEX_CMD_PREPEND") + commandStr + os.Getenv("FLEX_CMD_APPEND")
 	}
 	return commandStr
@@ -468,4 +502,25 @@ func buildCommand(ctx context.Context, api load.API, command load.Command) *exec
 	}
 
 	return exec.CommandContext(ctx, commandShell, secondParameter, command.Run)
+}
+
+// checkAssertion check the assertion
+func checkAssertion(assert load.Assert, output []byte) bool {
+
+	// return true if no matches defined
+	if assert.Match == "" && assert.NotMatch == "" {
+		return true
+	}
+
+	strOutput := string(output)
+
+	if assert.Match != "" && assert.NotMatch != "" && formatter.KvFinder("regex", strOutput, assert.Match) && formatter.KvFinder("regex", string(output), assert.NotMatch) {
+		return true
+	} else if assert.Match != "" && formatter.KvFinder("regex", strOutput, assert.Match) {
+		return true
+	} else if assert.NotMatch != "" && !formatter.KvFinder("regex", strOutput, assert.NotMatch) {
+		return true
+	}
+
+	return false
 }

--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -121,7 +121,7 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 
 	output, err := cmd.CombinedOutput()
 
-	// check assertion, if the result is false return immediately
+	// check if a assertion is defined and successfully passes before continuing, see function for detailed comments
 	if !checkAssertion(command.Assert, output) {
 		load.Logrus.WithFields(logrus.Fields{
 			"name": yml.Name,

--- a/internal/inputs/commands_test.go
+++ b/internal/inputs/commands_test.go
@@ -240,4 +240,90 @@ func TestEnvCommandCheck(t *testing.T) {
 	command = envCommandCheck(command)
 	assert.Equal(t, "echo hi && echo hello", command)
 
+	// check if wrap applies
+	os.Setenv("FLEX_CMD_PREPEND", "")
+	os.Setenv("FLEX_CMD_WRAP", "true")
+	commandWrap := envCommandCheck("echo hello")
+	assert.Equal(t, "\"echo hello\"", commandWrap)
+}
+
+func TestAssert(t *testing.T) {
+	load.Refresh()
+	config := load.Config{
+		Name: "echoFlex",
+		APIs: []load.API{
+			{
+				Name: "echo",
+				Commands: []load.Command{
+					{
+						Run:     "echo hi:bye",
+						SplitBy: `:`,
+						Assert: load.Assert{
+							Match: "hi",
+						},
+					},
+				},
+			},
+			{
+				Name: "echo2",
+				Commands: []load.Command{
+					{
+						Run:     "echo abc:def",
+						SplitBy: `:`,
+						Assert: load.Assert{
+							NotMatch: "BYE",
+						},
+					},
+				},
+			},
+			{
+				Name: "echo3",
+				Commands: []load.Command{
+					{
+						Run:     "echo abc:def",
+						SplitBy: `:`,
+						Assert: load.Assert{
+							NotMatch: "abc",
+						},
+					},
+				},
+			},
+			{
+				Name: "echo3",
+				Commands: []load.Command{
+					{
+						Run:     "echo abc:def",
+						SplitBy: `:`,
+						Assert: load.Assert{
+							Match:    "abc",
+							NotMatch: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dataStoreExpected := []interface{}{
+		map[string]interface{}{
+			"hi": "bye",
+		},
+	}
+
+	dataStore := []interface{}{}
+	RunCommands(&dataStore, &config, 0)
+	RunCommands(&dataStore, &config, 1)
+	RunCommands(&dataStore, &config, 2)
+	RunCommands(&dataStore, &config, 3)
+
+	assert.Len(t, dataStore, 3)
+
+	// we are only checking the first entry
+	expected := dataStoreExpected[0].(map[string]interface{})
+	actual := dataStore[0].(map[string]interface{})
+
+	for key, expectedValue := range expected {
+		actualValue := actual[key]
+		assert.Equalf(t, expectedValue, actualValue, "%s doesnt match - want: %v  got: %v", key, expectedValue, actualValue)
+	}
 }

--- a/internal/inputs/commands_test.go
+++ b/internal/inputs/commands_test.go
@@ -245,6 +245,9 @@ func TestEnvCommandCheck(t *testing.T) {
 	os.Setenv("FLEX_CMD_WRAP", "true")
 	commandWrap := envCommandCheck("echo hello")
 	assert.Equal(t, "\"echo hello\"", commandWrap)
+
+	// disable modifications to not effect other tests
+	load.Args.AllowEnvCommands = false
 }
 
 func TestAssert(t *testing.T) {

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -53,7 +53,8 @@ type ArgumentList struct {
 	DiscoverProcessLinux bool   `default:"false" help:"Discover Process info on Linux OS"`
 	NRJMXToolPath        string `default:"/usr/lib/nrjmx/" help:"Set a custom path for nrjmx tool"`
 	StructuredLogs       bool   `default:"false" help:"output logs in Json structure format for external tool parsing"`
-	AllowEnvCommands     bool   `default:"false" help:"enable to allow the use of FLEX_CMD_PREPEND & FLEX_CMD_APPEND"`
+	AllowEnvCommands     bool   `default:"false" help:"enable to allow the use of FLEX_CMD_PREPEND, FLEX_CMD_APPEND & FLEX_CMD_WRAP"`
+	StdinPipe            bool   `default:"false" help:"use cmd.StdinPipe for commands"`
 }
 
 // Args Infrastructure SDK Arguments List
@@ -379,7 +380,6 @@ type Command struct {
 	Dial             string            `yaml:"dial"`              // eg. google.com:80
 	Network          string            `yaml:"network"`           // default tcp
 	OS               string            `yaml:"os"`                // default empty for any operating system, if set will check if the OS matches else will skip execution
-
 	// Parsing Options - Body
 	Split       string `yaml:"split"`        // default vertical, can be set to horizontal (column) useful for outputs that look like a table
 	SplitBy     string `yaml:"split_by"`     // character/match to split by
@@ -398,7 +398,14 @@ type Command struct {
 	RegexMatches []RegMatch `yaml:"regex_matches"`
 
 	// Mask run command
-	HideErrorExec bool `yaml:"hide_error_exec"` // prevent executable command from getting displayed when there is an error
+	HideErrorExec bool   `yaml:"hide_error_exec"` // prevent executable command from getting displayed when there is an error
+	Assert        Assert `yaml:"assert"`          // use command as an assertion to block other commands unless successful
+}
+
+// Assert uses command as an assertion to block or pass following commands
+type Assert struct {
+	Match    string `yaml:"match"`     // containue if output matches this string
+	NotMatch string `yaml:"not_match"` // continue if output does not match this string
 }
 
 // Pagination handles request pagination

--- a/internal/runtime/flex.go
+++ b/internal/runtime/flex.go
@@ -7,7 +7,6 @@ package runtime
 
 import (
 	"fmt"
-	"github.com/newrelic/nri-flex/internal/utils"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"github.com/newrelic/nri-flex/internal/config"
 	"github.com/newrelic/nri-flex/internal/load"
 	"github.com/newrelic/nri-flex/internal/outputs"
+	"github.com/newrelic/nri-flex/internal/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -60,7 +60,7 @@ func CommonPostInit() {
 	}
 }
 
-// Pre-initialization common to all runtime types here
+// CommonPreInit Pre-initialization common to all runtime types here
 func CommonPreInit() {
 	load.StartTime = load.MakeTimestamp()
 	setEnvs()
@@ -71,7 +71,7 @@ func CommonPreInit() {
 	}
 }
 
-// Common run (once) function
+// RunFlex Common run (once) function
 func RunFlex(instance Instance) error {
 	setStatusCounters()
 	setupLogger()


### PR DESCRIPTION
Adds 3 gated features:

### 1. StdinPipe
	   StdinPipe            bool   `default:"false" help:"use cmd.StdinPipe for commands"`

When enabled stdinPipe will be used for commands, some executables exit immediately causing an exit status 1 with no error. Allowing this functionality allows the command to be run successfully with the expected output.


### 2. FLEX_CMD_WRAP
Automatically wrap a command in quotes (Requires AllowEnvCommands enabled).
This is useful when env prepend or append is being used and the subsequent command needs to be wrapped so it can be executed properly.

### 3. Assert command output before processing
Useful for when example `netstat` is not available on a system but `ss` is, this provides a more gracious way to assert the output and skip if required.

Add an assert block with a nested variable of `match` and/or `not_match`.
Note both options use regex.

Examples:
```yml
#### Command output must contain the string "hi" - this will continue
integrations:
  - name: nri-flex
    config:
      name: SomeIntegration
      apis:
        - event_type: SomeSample
          commands:
            - run: "echo hi:bye"
              split_by: ":"
              assert:
                match: hi #### <--------
```

```yml
#### Command output must contain the string "foo" - this will NOT continue!
integrations:
  - name: nri-flex
    config:
      name: SomeIntegration
      apis:
        - event_type: SomeSample
          commands:
            - run: "echo hi:bye"
              split_by: ":"
              assert:
                match: foo #### <--------
```

```yml
#### Command output must contain the string "hi" and not contain the string "foo - this will continue
integrations:
  - name: nri-flex
    config:
      name: SomeIntegration
      apis:
        - event_type: SomeSample
          commands:
            - run: "echo hi:bye"
              split_by: ":"
              assert:
                match: hi ##### <------------
                not_match: foo #### <--------
```