### PR TITLE
Revert "ci: remove travis yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+---
+language: go
+
+go:
+  - "1.13"
+
+services:
+  - docker
+
+script: make clean build-ci
+
+deploy:
+ - provider: script
+   cleanup: false
+   script: make release
+   on:
+     tags: true
+
+env:
+  global:
+    # github token
+    - secure: "qz3I7trkvwFz8ad22VA1FVtAW0xTnp55nuFCMo/drQ2kopMulPLXtIm3chTEnjErbTNuPAIYWLL1VkK2fUSnOLyblFSoxtndJtW63zZ0gsSFS1Lk+Dd//XpPaq3sxCPY3vD3ogYXexogEH79W+6tJL5Pci6p+Tgln37J+dWehEB4FuAanUJERyjdZ0mIWkPiz3NJNXKqPK9HsL9zp6H12s3JL78XDluG8aul39jMDbnczwLjLTOfpGdwAFzWchgFOlKwheuHsHUXk6NkO53vHbl489dOzJ+2Yzk9flS6p9xp9pDVOni3qcJoiWDGkayg2gDHOjZ0WBuR2CMK68HcPYDdN/yeqMkZqDXuEW7HiDQq4jvYT5tNHz+xAlWS/oYGICR8etriMxu5fh8itF6qnsEFtZANjqWf6XQIz9uvBjPG9bkdSf5ZkwJD88wPb0Bkin5HTyeODLbUyvPBK/ue4qrZ5UqmZ//BQ4Gu4dUlGa+/6HjZRUi40a4/Tg+epsayhdz9AJhT+XxK9vicSXKUF5bqX5ar4v+Xbw+PNVHMvWaBZ2J7I4SitEhZJ2AcwwB1lqBY1GcJLuLU6eDn3vD78k5qdcqWQ7FprlsrZ70V7WH3JdDoXoMqyaXOSDVN+FhPsb3ia0WhU1mE7MpGIms8ZkGHfxHbkPJuDZSrhKLkH0k="
+    # Snyk token
+    - secure: "Y05CFwcRnLeLUWqGoPUrIzsQPglSBAyG1p5FTrCcF/qgMLSxF25cZtGez/foi+6hPF6abD4gFx8sJVEQaZGYhWuvqOpbhRbwx7l7sBRGiIzJ/23PIKUY0PhET2GJqBkMvE5DVUsUVPHHy2VRuCcjI5CSHzzDd8ix93YYDQhxpli3Ha4sLocmzmckfsCcHPXqF1Tz0B6KAuK8SDzkrqqJ+s8xOPby6Vkcd8k+GcKXSOh4dPhc2vjbYZn6Asn0jUN4z51HH/nbmsMDZbM4A3eRXtxWh4WCfY0GmPZpBQWuIJGTKwGjs37ASAH9r5w+f3XG5pTtsQaJoFur/VG0rnKma//2BaHB/fcE+6C506Iva5Ln566chMjP5+guL/S+yBZkEJXRF3gdgmmuJVQBxxWXKMxBpV+a6bwbVxOGkIDGwDtW/3uZrUlGD4nFjxVUt+yFZq53lHjGm7Z8J/qeYZZo1wu7y5oU9g6ZjHrVq1ng7IfalFpYWc6yx89a/woT8RfJJDRkB14kwHwTK6LSUO8BGZ0/yRj4EALMh+wRzbv0LS7fpL5Ei40/tbxbCyvRBjdeywXRtH36jgB7OOmhLwP+VonqpQrLEnlyOIvk7v1/LvPJJFdd5UneytY5yZ09F0jGcEvGuUsCL9yxk5dS+YTezB07xprsUjXD7+Bui9h1ftk="


### PR DESCRIPTION
This reverts commit 237c71489ad403fafee29ccb7d1bfe1bea391340.

Restoring to enable releases while there's no GHA counterpart.