### PR TITLE
added command output: csv and http contentType: text/csv support

### DIFF
--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -313,6 +313,12 @@ func processOutput(dataStore *[]interface{}, output string, dataSample *map[stri
 		case load.Jmx:
 			*processType = "jmx"
 			ParseJMX(dataStore, dataInterface, command, dataSample)
+		case load.TypeCSV:
+			err := processCsv(dataStore, "", "command output", &dataOutput, command.SetHeader)
+			if err != nil {
+				load.Logrus.WithError(err).Errorf("Failed to process text/csv body")
+			}
+
 		}
 	}
 }
@@ -418,6 +424,9 @@ func processRawCol(dataStore *[]interface{}, dataSample *map[string]interface{},
 
 // detectCommandOutput currently only supports checking if json output
 func detectCommandOutput(dataOutput string, commandOutput string) (string, interface{}) {
+	if commandOutput == load.TypeCSV {
+		return "csv", nil
+	}
 	if commandOutput == load.Jmx {
 		dataOutputLines := strings.Split(strings.TrimSuffix(dataOutput, "\n"), "\n")
 		startLine := 0

--- a/internal/inputs/http.go
+++ b/internal/inputs/http.go
@@ -110,6 +110,14 @@ func RunHTTP(dataStore *[]interface{}, doLoop *bool, yml *load.Config, api load.
 						handleJSON(dataStore, []byte(jsonBody), &resp, doLoop, reqURL, nextLink, api.ReturnHeaders)
 					}
 				}
+			case contentType == "text/csv":
+				body, _ := ioutil.ReadAll(resp.Body)
+				stringBody := string(body)
+				err := processCsv(dataStore, "", "", &stringBody, api.SetHeader)
+				if err != nil {
+					load.Logrus.WithError(err).Errorf("http: URL %v failed to process text/csv body resp.Body", *reqURL)
+				}
+
 			default:
 				// some apis do not specify a content-type header, if not set attempt to detect if the payload is json
 				body, err := ioutil.ReadAll(resp.Body)

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -129,6 +129,7 @@ const (
 	TypeCname          = "cname"
 	TypeJSON           = "json"
 	TypeXML            = "xml"
+	TypeCSV            = "csv"
 	TypeColumns        = "columns"
 	Contains           = "contains"
 )


### PR DESCRIPTION
Address issue/feature #273 
- added `output: csv` support for commands function

```yaml
integrations:
  - name: nri-flex 
    config: 
      name: sampleEvents
      apis:
        - name: apexExecute
          commands:
            - run: curl -s http://127.0.0.1:8887/ApexUnexpectedExcept.csv
              output: csv   
```

- added `text/csv` content-type support  for http function

```yaml
integrations:
  - name: nri-flex 
    config: 
      name: httpSampleABC
      apis: 
        - event_type: httpSampleABC
          url: http://127.0.0.1:8887/ApexUnexpectedExcept.csv

```