### PR TITLE
fix: panic when using ${lookup.<EventType>:<Attribute>}

### DIFF
--- a/internal/processor/data.go
+++ b/internal/processor/data.go
@@ -22,8 +22,8 @@ func RunDataHandler(dataSets []interface{}, samplesToMerge *load.SamplesToMerge,
 		"name": cfg.Name,
 	}).Debug("processor-data: running data handler")
 
-	if cfg.APIs[originalAPINo].Jq != "" {
-		dataSets = runJq(dataSets, cfg.APIs[originalAPINo])
+	if cfg.APIs[i].Jq != "" {
+		dataSets = runJq(dataSets, cfg.APIs[i])
 	}
 
 	for _, dataSet := range dataSets {


### PR DESCRIPTION
- fixed panic issue when using `${lookup.<EventType>:<Attribute>}` function 
```log
panic: runtime error: index out of range [1] with length 1

goroutine 14 [running]:
github.com/newrelic/nri-flex/internal/processor.RunDataHandler(0xc00097dd20, 0x1, 0x1, 0xc00009e6e0, 0x0, 0xc0003f18c0, 0x1)
	/Users/haihongren/go/src/github.com/newrelic/nri-flex/internal/processor/data.go:25 +0x601
github.com/newrelic/nri-flex/internal/config.RunSync(0xc0003dd800, 0x19, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/haihongren/go/src/github.com/newrelic/nri-flex/internal/config/config.go:272 +0x2ca
github.com/newrelic/nri-flex/internal/config.FetchLookups(0xc000034900, 0x1, 0xc00009e6e0, 0x1)
	/Users/haihongren/go/src/github.com/newrelic/nri-flex/internal/config/fetch.go:151 +0x707
github.com/newrelic/nri-flex/internal/config.FetchData(0x1, 0xc000034900, 0xc00009e6e0, 0xc00009e6e0, 0x0, 0xc000034900)
	/Users/haihongren/go/src/github.com/newrelic/nri-flex/internal/config/fetch.go:33 +0x279
github.com/newrelic/nri-flex/internal/config.Run(0x7ffeefbff987, 0x19, 0xc000712960, 0x1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/haihongren/go/src/github.com/newrelic/nri-flex/internal/config/config.go:214 +0x2be
github.com/newrelic/nri-flex/internal/config.RunFiles.func2(0xc000910fb0, 0xc0001086c0, 0x7ffeefbff987, 0x19, 0xc000712960, 0x1c, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/haihongren/go/src/github.com/newrelic/nri-flex/internal/config/config.go:321 +0x277
created by github.com/newrelic/nri-flex/internal/config.RunFiles
	/Users/haihongren/go/src/github.com/newrelic/nri-flex/internal/config/config.go:314 +0x6e6
```