### PR TITLE
wip: add zfs example

### DIFF
--- a/examples/zfs.yml
+++ b/examples/zfs.yml
@@ -35,10 +35,3 @@ apis:
         split: horizontal
         split_by: \s+
         set_header: [poolName,_garbage,_garbage,readIoPerSecond,writeIoPerSecond,readBytesPerSecond,writeBytesPerSecond,readLatencyNs,writeLatencyNs,readDiskLatencyNs,writeDiskLatencyNs]
-    metric_parser:
-      mode: regex
-      metrics:
-        IoPerSecond: PRATE
-      namespace:
-        existing_attr:
-          - poolName

--- a/examples/zfs.yml
+++ b/examples/zfs.yml
@@ -12,17 +12,21 @@ apis:
         split: horizontal
         split_by: \s+
         set_header: [datasetName,available,used,usedSnap,usedDds,usedRefReserv,usedChild,type,compressratio]
-  - name: ZfsModule
+  - name: ZfsArc
     commands:
       - run: cat /proc/spl/kstat/zfs/arcstats | grep -v 'l2_' | sed -r 's/\s+[0-9]\s+/:/'
         split_by: ":"
         line_start: 2
     snake_to_camel: true
+    rename_keys:
+      Hits$: HitsPerSecond
+      Misses$: MissesPerSecond
+      ^hits$: hitsPerSecond
+      ^misses$: missesPerSecond
     metric_parser:
       mode: regex
-      metrics:
-        Hits$: PRATE
-        Misses$: PRATE
+      metrics: # Key names after processing snake_to_camel and rename_keys
+        PerSecond$: RATE
       namespace:
         custom_attr: "zfsModuleArc"
   - name: ZpoolIoStat

--- a/examples/zfs.yml
+++ b/examples/zfs.yml
@@ -5,16 +5,15 @@ apis:
       - run: 'zpool list -Hpo name,health,size,expandsize,allocated,free,fragmentation,capacity,dedup,comment,version'
         split: horizontal
         split_by: \s+
-        set_header: [name,health,size,expandsize,allocated,free,fragmentationPercent,capacityPercent,dedup,comment,version]
+        set_header: [poolName,health,size,expandsize,allocated,free,fragmentationPercent,capacityPercent,dedup,comment,version]
   - name: Zfs
     commands:
       - run: zfs list -Hpo space,type,compressratio -t all
         split: horizontal
         split_by: \s+
-        set_header: [name,available,used,usedSnap,usedDds,usedRefReserv,usedChild,type,compressratio]
+        set_header: [datasetName,available,used,usedSnap,usedDds,usedRefReserv,usedChild,type,compressratio]
   - name: ZfsModule
     commands:
-      # l2arc metrics are grepped out since most people dont care or have l2arc enabled
       - run: cat /proc/spl/kstat/zfs/arcstats | grep -v 'l2_' | sed -r 's/\s+[0-9]\s+/:/'
         split_by: ":"
         line_start: 2
@@ -22,7 +21,24 @@ apis:
     metric_parser:
       mode: regex
       metrics:
-        Hits$: DELTA
-        Misses$: DELTA
+        Hits$: PRATE
+        Misses$: PRATE
       namespace:
         custom_attr: "zfsModuleArc"
+  - name: ZpoolIoStat
+    strip_keys:
+      - _garbage
+    commands:
+      # First positional argument to zpool iostat is the sampling interval. Must be lower than all the timeouts present in this file
+      - run: 'zpool iostat -Hylp 55 1'
+        timeout: 57000
+        split: horizontal
+        split_by: \s+
+        set_header: [poolName,_garbage,_garbage,readIoPerSecond,writeIoPerSecond,readBytesPerSecond,writeBytesPerSecond,readLatencyNs,writeLatencyNs,readDiskLatencyNs,writeDiskLatencyNs]
+    metric_parser:
+      mode: regex
+      metrics:
+        IoPerSecond: PRATE
+      namespace:
+        existing_attr:
+          - poolName

--- a/examples/zfs.yml
+++ b/examples/zfs.yml
@@ -1,0 +1,28 @@
+name: zfs
+apis:
+  - name: Zpool
+    commands:
+      - run: 'zpool list -Hpo name,health,size,expandsize,allocated,free,fragmentation,capacity,dedup,comment,version'
+        split: horizontal
+        split_by: \s+
+        set_header: [name,health,size,expandsize,allocated,free,fragmentationPercent,capacityPercent,dedup,comment,version]
+  - name: Zfs
+    commands:
+      - run: zfs list -Hpo space,type,compressratio -t all
+        split: horizontal
+        split_by: \s+
+        set_header: [name,available,used,usedSnap,usedDds,usedRefReserv,usedChild,type,compressratio]
+  - name: ZfsModule
+    commands:
+      # l2arc metrics are grepped out since most people dont care or have l2arc enabled
+      - run: cat /proc/spl/kstat/zfs/arcstats | grep -v 'l2_' | sed -r 's/\s+[0-9]\s+/:/'
+        split_by: ":"
+        line_start: 2
+    snake_to_camel: true
+    metric_parser:
+      mode: regex
+      metrics:
+        Hits$: RATE
+        Misses$: RATE
+      namespace:
+        custom_attr: "zfsModuleArc"

--- a/examples/zfs.yml
+++ b/examples/zfs.yml
@@ -22,7 +22,7 @@ apis:
     metric_parser:
       mode: regex
       metrics:
-        Hits$: RATE
-        Misses$: RATE
+        Hits$: DELTA
+        Misses$: DELTA
       namespace:
         custom_attr: "zfsModuleArc"


### PR DESCRIPTION
This PR adds a flex config file which allows to parse several metrics from [ZFS](https://openzfs.org/wiki/Main_Page), the Zettabyte filesystem.

> OpenZFS is an open-source storage platform. It includes the functionality of both traditional file systems and volume manager. It has many advanced features including:
> - Protection against data corruption. Integrity checking for both data and metadata.
> - Continuous integrity verification and automatic “self-healing” repair
> - Data redundancy with mirroring, RAID-Z1/2/3 [and DRAID]
> [...]

This integration will help with monitoring of servers and K8s nodes using ZFS, as the `StorageSample` reported by the agent does not contain contains any info about ZFS filesystems.

Most metrics are gathered by simply parsed `zfs` and `zpool` commands. Additionally, arc stats are also gathered from `/proc/spl/kstat/zfs/arcstats`.

### Scope

- [x] Zpool metrics (free, avail, health...)
- [ ] Zpool detailed metrics (io/checksum errors)
- [x] Dataset metrics
- [x] `zpool iostat` metrics
- [x] ARC metrics
- [ ] More refined ARC metrics (more `DELTA`/`RATE` types where relevant)
- [ ] Other kstat metrics?
- [ ] Sample dashboard


![DeepinScreenshot_select-area_20210222221338](https://user-images.githubusercontent.com/969721/108770953-40871380-755b-11eb-96a1-19dd839dd2b0.png)
