### PR TITLE
fix: context errors not captured

### DIFF
--- a/internal/inputs/commands.go
+++ b/internal/inputs/commands.go
@@ -130,53 +130,43 @@ func commandRun(dataStore *[]interface{}, yml *load.Config, command load.Command
 		return
 	}
 
-	if err != nil {
+	contextError := ctx.Err()
+
+	if err != nil || contextError != nil {
+		contextErrorStr := ""
+		if contextError != nil {
+			contextErrorStr = contextError.Error()
+		}
+
+		load.Logrus.WithFields(logrus.Fields{
+			"exec":        command.Run,
+			"err":         err,
+			"context_err": contextErrorStr,
+			"suggestion":  "if you are handling this error case, ignore",
+		}).Debug("command: failed")
+
 		if command.HideErrorExec {
-			load.Logrus.WithFields(logrus.Fields{
-				"exec":       command.Run,
-				"err":        err,
-				"suggestion": "if you are handling this error case, ignore",
-			}).Debug("command: failed")
 			errorSample := map[string]interface{}{
-				"error":      err,
-				"error_msg":  string(output),
-				"error_exec": "COMMAND HIDDEN!",
+				"error":         err,
+				"error_msg":     string(output),
+				"context_error": contextErrorStr,
+				"error_exec":    "COMMAND HIDDEN!",
 			}
 			*dataStore = append(*dataStore, errorSample)
 			return
 		}
-		load.Logrus.WithFields(logrus.Fields{
-			"exec":       command.Run,
-			"err":        err,
-			"suggestion": "if you are handling this error case, ignore",
-		}).Debug("command: failed")
+
 		errorSample := map[string]interface{}{
-			"error":      err,
-			"error_msg":  string(output),
-			"error_exec": command.Run,
+			"error":         err,
+			"error_msg":     string(output),
+			"context_error": contextErrorStr,
+			"error_exec":    command.Run,
 		}
 		*dataStore = append(*dataStore, errorSample)
 		return
 	}
 
-	err = ctx.Err()
-	if err != nil {
-		if err == context.DeadlineExceeded {
-			load.Logrus.WithFields(logrus.Fields{
-				"exec": command.Run,
-				"err":  err,
-			}).Debug("command: timed out")
-		} else {
-			load.Logrus.WithFields(logrus.Fields{
-				"exec": command.Run,
-				"err":  err,
-			}).Debug("command: execution failed")
-		}
-		errorSample := map[string]interface{}{
-			"error": err,
-		}
-		*dataStore = append(*dataStore, errorSample)
-	} else if len(output) > 0 {
+	if len(output) > 0 {
 		if command.SplitOutput != "" {
 			splitOutput(dataStore, string(output), command, startTime)
 		} else {


### PR DESCRIPTION
When an error occurs during command execution, the code returns early and does not capture the context error. 
Things like command timeouts - context deadline exceeded are not captured.

cc/ @haihongren 