### PR TITLE
Added ethtool config

### DIFF
--- a/examples/ethtool.yml
+++ b/examples/ethtool.yml
@@ -1,0 +1,16 @@
+---
+integrations:
+  - name: nri-flex
+    interval: 30s
+    config:
+      name: ethtoolFlex
+      apis:
+        - event_type: ethtoolSample
+          name: enaStats
+          commands:
+            - run: ethtool -S eth0
+              split_by: ":"
+          remove_keys:
+            - NICStatistics
+          rename_keys:
+            \s+: ""


### PR DESCRIPTION
Sends the output of "ethtool -S eth0" and removes whitespace in attributes as well as the "NIC Statistics" header