### PR TITLE
fix: handle +Inf

### DIFF
--- a/internal/processor/create.go
+++ b/internal/processor/create.go
@@ -563,7 +563,7 @@ func AutoSetMetricInfra(k string, v interface{}, metricSet *metric.Set, metrics 
 	value := cleanValue(&v)
 	parsed, err := strconv.ParseFloat(value, 64)
 
-	if err != nil || strings.EqualFold(value, "infinity") || strings.EqualFold(value, "inf") || strings.EqualFold(value, "nan") {
+	if err != nil || strings.EqualFold(value, "infinity") || strings.EqualFold(value, "inf") || strings.EqualFold(value, "+inf") || strings.EqualFold(value, "nan") {
 		checkError(metricSet.SetMetric(k, value, metric.ATTRIBUTE))
 	} else {
 		foundKey := false


### PR DESCRIPTION
The infra SDK cannot handle +Inf values when marshalling to JSON.
This checks the parsed value and allows it to be set as an attribute rather then gauge.

[Slack thread](https://newrelic.slack.com/archives/CPVCA6Y86/p1616468123018400?thread_ts=1616468102.018300&cid=CPVCA6Y86)

cc/ @bpschmitt @Noly @josemore 