### PR TITLE
Aliyun(Alibaba Cloud) CloudMonitor support, async rate throttle and minor fix for a racing condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.6.1
 	github.com/vertica/vertica-sql-go v0.1.3
+	go.uber.org/ratelimit v0.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -237,6 +239,9 @@ github.com/vertica/vertica-sql-go v0.1.3 h1:trJfygrq2+SlJJs9i2MBioA2E5oufVSo/H3J
 github.com/vertica/vertica-sql-go v0.1.3/go.mod h1:2LGtkNSdFF5CTJYeUA5qWfREuvYaql+51fNzmoD5W7c=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/aliyun/escape.go
+++ b/internal/aliyun/escape.go
@@ -1,0 +1,37 @@
+package aliyun
+
+func shouldEscape(c byte) bool {
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '_' || c == '-' || c == '~' || c == '.' {
+		return false
+	}
+	return true
+}
+func escape(s string) string {
+	hexCount := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c) {
+			hexCount++
+		}
+	}
+
+	if hexCount == 0 {
+		return s
+	}
+
+	t := make([]byte, len(s)+2*hexCount)
+	j := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case shouldEscape(c):
+			t[j] = '%'
+			t[j+1] = "0123456789ABCDEF"[c>>4]
+			t[j+2] = "0123456789ABCDEF"[c&15]
+			j += 3
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}

--- a/internal/aliyun/signer.go
+++ b/internal/aliyun/signer.go
@@ -1,0 +1,136 @@
+// Aliyun signer
+
+package aliyun
+
+import (
+	"crypto/hmac"
+	"strconv"
+
+	// #nosec
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+
+	// #nosec
+	"math/rand"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/newrelic/nri-flex/internal/load"
+)
+
+// BasicDateFormat
+const (
+	BasicDateFormat  = "2006-01-02T15:04:05Z0700"
+	SignatureVersion = "1.0"
+	APIVersion       = "2019-01-01"
+	SignatureMethod  = "HMAC-SHA1"
+)
+
+// Signer Key and secret
+type Signer struct {
+	Key    string
+	Secret string
+}
+
+// Sign URL
+func (s *Signer) Sign(r *http.Request) (string, error) {
+	var err error
+	// #nosec
+	var signedURL string
+	reqMethod := r.Method
+	paramsToSign := addSignerParams(r, s.Key)
+	stringToSign := CanonicalQueryString(paramsToSign)
+	stringToSign = reqMethod + "&%2F&" + stringToSign
+	signature := ShaHmac1(stringToSign, s.Secret)
+	if err != nil {
+		return signedURL, err
+	}
+	paramsToSign.Add("Signature", signature)
+
+	signedURL = r.URL.Scheme + "://" + r.URL.Host + r.URL.Path + "?" + paramsToSign.Encode()
+	load.Logrus.Debugf("Aliyun Signer: SignedUrl: %v ", signedURL)
+	return signedURL, nil
+}
+
+func ShaHmac1(source, secret string) string {
+	/*
+		https://www.alibabacloud.com/help/doc-detail/25492.htm?spm=a2c63.p38356.b99.700.21246d94fcNh6T
+
+		Note When you calculate the signature, the key value specified by RFC 2104 is your AccessKeySecret with an ampersand (&) which has an ASCII value of 38. For more information, see Create an AccessKey pair.
+	*/
+	key := []byte(secret + "&")
+	hmac := hmac.New(sha1.New, key)
+	_, err := hmac.Write([]byte(source))
+	if err != nil {
+		load.Logrus.Errorf("Aliyun Signer: ShaHmac1 Error: %v", err)
+	}
+	signedBytes := hmac.Sum(nil)
+	signedString := base64.StdEncoding.EncodeToString(signedBytes)
+
+	load.Logrus.Debugf("Aliyun Signer: String to sign: %v", source)
+	load.Logrus.Debugf("Aliyun Signer: Signature: %v", signedString)
+
+	return signedString
+}
+
+func getNonce() string {
+	s := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(s)
+	return strconv.FormatInt(r.Int63(), 10)
+}
+
+var safeNonce = func(fn func() string) string {
+	return fn()
+}
+
+func addSignerParams(r *http.Request, key string) url.Values {
+	t := time.Now().UTC().Format(BasicDateFormat)
+	signatureNonce := safeNonce(getNonce)
+	params := r.URL.Query()
+	if _, ok := params["Version"]; !ok {
+		params.Add("Version", APIVersion)
+	}
+	if _, ok := params["SignatureVersion"]; !ok {
+		params.Add("SignatureVersion", SignatureVersion)
+	}
+	if _, ok := params["SignatureMethod"]; !ok {
+		params.Add("SignatureMethod", SignatureMethod)
+	}
+	if _, ok := params["AccessKeyId"]; !ok {
+		params.Add("AccessKeyId", key)
+	}
+	if _, ok := params["Timestamp"]; !ok {
+		params.Add("Timestamp", t)
+	}
+	if _, ok := params["SignatureNonce"]; !ok {
+		params.Add("SignatureNonce", signatureNonce)
+	}
+	if _, ok := params["SignatureType"]; !ok {
+		params.Add("SignatureType", "")
+	}
+	return params
+}
+
+func CanonicalQueryString(query url.Values) string {
+	keys := make([]string, 0)
+
+	for key := range query {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var a []string
+	for _, key := range keys {
+		k := escape(key)
+		sort.Strings(query[key])
+		for _, v := range query[key] {
+			kv := fmt.Sprintf("%s=%s", k, escape(v))
+			a = append(a, kv)
+		}
+	}
+	queryStr := strings.Join(a, "&")
+	return url.QueryEscape(queryStr)
+}

--- a/internal/aliyun/signer_test.go
+++ b/internal/aliyun/signer_test.go
@@ -1,0 +1,24 @@
+package aliyun
+
+import (
+	"testing"
+
+	"github.com/parnurzeal/gorequest"
+	"gotest.tools/assert"
+)
+
+func TestSign(t *testing.T) {
+	expectedSignedUrl := `http://ecs.ap-southeast-2.aliyuncs.com/?AccessKeyId=testkey1&Action=DescribeRegions&Format=JSON&RegionId=ap-southeast-2&Signature=q7HtOs3jumOb33wnGptb7ihl4ak%3D&SignatureMethod=HMAC-SHA1&SignatureNonce=4751981231928800661&SignatureType=&SignatureVersion=1.0&Timestamp=2021-04-19T05%3A21%3A43Z&Version=2019-01-01`
+	reqURL := "http://ecs.ap-southeast-2.aliyuncs.com/?Action=DescribeRegions&Format=JSON&RegionId=ap-southeast-2&SignatureNonce=4751981231928800661&Timestamp=2021-04-19T05%3A21%3A43Z&Version=2019-01-01"
+
+	signer := Signer{
+		Key:    "testkey1",
+		Secret: "testSecret1",
+	}
+	request := gorequest.New()
+	request = request.Get(reqURL)
+	r, _ := request.MakeRequest()
+	signedUrl, _ := signer.Sign(r)
+	assert.Equal(t, expectedSignedUrl, signedUrl)
+
+}

--- a/internal/config/fetch.go
+++ b/internal/config/fetch.go
@@ -69,6 +69,7 @@ func FetchData(apiNo int, yml *load.Config, samplesToMerge *load.SamplesToMerge)
 	// cache output into datastore for later use
 	// if the source was a cache itself, we don't store it
 	if len(dataStore) > 0 {
+		load.CacheStoreLock.Lock()
 		if api.URL != "" {
 			if yml.Datastore == nil {
 				yml.Datastore = map[string][]interface{}{}
@@ -85,6 +86,8 @@ func FetchData(apiNo int, yml *load.Config, samplesToMerge *load.SamplesToMerge)
 			}
 			yml.Datastore[api.File] = dataStore
 		}
+
+		load.CacheStoreLock.Unlock()
 	}
 
 	return dataStore

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -47,6 +47,7 @@ type ArgumentList struct {
 	GitBranch               string `default:"master" help:"Checkout to specified git branch"`
 	GitCommit               string `default:"" help:"Checkout to specified git commit, if set will not use branch"`
 	ProcessConfigsSync      bool   `default:"false" help:"Process configs synchronously rather then async"`
+	AsyncRate               int    `default:"0" help:" When Process Configs in Async mode, limit the rate to run the configs, e.g. 20 per second (default: 0, unlimited)"`
 	// ProcessDiscovery      bool   `default:"true" help:"Enable process discovery"`
 	EncryptPass          string `default:"" help:"Pass to be encypted"`
 	PassPhrase           string `default:"N3wR3lic!" help:"PassPhrase used to de/encrypt"`
@@ -139,6 +140,10 @@ const (
 var MetricsStore = struct {
 	sync.RWMutex
 	Data []Metrics
+}{}
+
+var CacheStoreLock = struct {
+	sync.RWMutex
 }{}
 
 // MetricsStoreAppend Append data to store
@@ -260,6 +265,7 @@ type API struct {
 	EventsOnly        bool              `yaml:"events_only"`    // only generate events
 	Merge             string            `yaml:"merge"`          // merge into another eventType
 	RunAsync          bool              `yaml:"run_async" `     // API block to run in Async mode when using with lookupstore
+	AsyncRate         int               `yaml:"async_rate"`     //Async Request Throttle Rate
 	JoinKey           string            `yaml:"join_key"`       // merge into another eventType
 	Prefix            string            `yaml:"prefix"`         // prefix attribute keys
 	File              string            `yaml:"file"`

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -308,7 +308,8 @@ type API struct {
 	SplitArray        bool              `yaml:"split_array"`        // convert array to samples, use SetHeader to set attribute name
 	LeafArray         bool              `yaml:"leaf_array"`         // convert array element to samples when SplitArray, use SetHeader to set attribute name
 	Scp               SCP               `yaml:"scp"`
-	HWSigner          HWSigner          `yaml:"hw_signer"` // Huawei Cloud Service API signer
+	HWSigner          HWSigner          `yaml:"hw_signer"`     // Huawei Cloud Service API signer
+	AliyunSigner      AliyunSigner      `yaml:"aliyun_signer"` // Huawei Cloud Service API signer
 	// Key manipulation
 	ToLower      bool              `yaml:"to_lower"`       // convert all unicode letters mapped to their lower case.
 	ConvertSpace string            `yaml:"convert_space"`  // convert spaces to another char
@@ -497,6 +498,12 @@ type SCP struct {
 
 // HWSigner struct
 type HWSigner struct {
+	Key    string `yaml:"key"`
+	Secret string `yaml:"secret"`
+}
+
+// AliyunSigner struct
+type AliyunSigner struct {
 	Key    string `yaml:"key"`
 	Secret string `yaml:"secret"`
 }

--- a/internal/runtime/flex.go
+++ b/internal/runtime/flex.go
@@ -195,6 +195,11 @@ func setEnvs() {
 	if err == nil && configSync {
 		load.Args.ProcessConfigsSync = configSync
 	}
+	asyncRate, err := strconv.Atoi(os.Getenv("ASYNC_RATE"))
+	if err == nil && asyncRate > 0 {
+		load.Args.AsyncRate = asyncRate
+	}
+
 	fargate, err := strconv.ParseBool(os.Getenv("FARGATE"))
 	if err == nil && fargate {
 		load.Args.Fargate = fargate


### PR DESCRIPTION
#### Feature: Aliyun(Alibaba Cloud) CloudMonitor API Signer support
- Aliyun Cloud Service API requires:
  1. The request to be signed with Alibaba Cloud AccessKey using HMAC-SHA1 signature algorithm. 
  2. The request rate not to exceed the API rate limit.

- `aliyun_signer` and `async_rate` functions are added to support the above requirement
```yaml

      apis:
        - event_type: <..>
          url: <...>
           ....
          aliyun_signer:
            key: ${var:KEY}
            secret: ${var:SECRET}

          run_async: true
          async_rate: 20
```
> **aliyun_signer**
The key and secret from Aliyun Cloud 

> **async_rate**
The rate at which Flex sends the request (when `run_async` is true) , e.g. 20 means 20 requests per sec.
If not defined or 0, it will be unlimited.


- Sample Aliyun integration yml ( Aliyun SLB service in the example)
```yaml
integrations:
  - name: nri-flex
    interval: 5m
    config:
      name: AliyunIntegration
      variable_store:
        # Config Metrics Definition in the METRICS_FILE json file
        # Config EVENTTYPE 
        METRICS_FILE: <PATH>/aliyun_metrics_SLB.json
        EVENTTYPE: aliyunSLBSample

        # Config Aliyun Account Access Info
        # The credentials can be obfuscated using Infra "Secret" feature
        REGION: "ap-southeast-2"
        KEY: <YOUR Aliyun access key>
        SECRET: <YOUR Aliyun access secret>

        # Query time range
        STARTTIME: ${timestamp:ms-5min}
        ENDTIME: ${timestamp:ms}

      apis:
        - event_type: sourceSample
          commands:
            - run: cat ${var:METRICS_FILE}
          ignore_output: true

        - event_type: "${var:EVENTTYPE}"
          name: metricData
          url: http://metrics.${var:REGION}.aliyuncs.com/?Action=${lookup.sourceSample:Action}&Namespace=${lookup.sourceSample:Namespace}&MetricName=${lookup.sourceSample:MetricName}&Format=JSON&StartTime=${var:STARTTIME}&EndTime=${var:ENDTIME}&Period=60

          aliyun_signer:
            key: ${var:KEY}
            secret: ${var:SECRET}

          run_async: true
          async_rate: 20

          jq: ".[]|[{RequestId,Code,Success,Period}+(.Datapoints|fromjson|.[])]"

          rename_keys:
            Average: ${lookup.sourceSample:Service}.${lookup.sourceSample:MetricName}.Average
            Maximum: ${lookup.sourceSample:Service}.${lookup.sourceSample:MetricName}.Maximum
            Minimum: ${lookup.sourceSample:Service}.${lookup.sourceSample:MetricName}.Minimum
            Value: ${lookup.sourceSample:Service}.${lookup.sourceSample:MetricName}.Value
            Sum: ${lookup.sourceSample:Service}.${lookup.sourceSample:MetricName}.Sum
            Count: ${lookup.sourceSample:Service}.${lookup.sourceSample:MetricName}.Count
            timestamp: timestamp_original

          custom_attributes:
            Region: ${var:REGION}
            Action: ${lookup.sourceSample:Action}
            Namespace: ${lookup.sourceSample:Namespace}
            MetricName: ${lookup.sourceSample:MetricName}

```
- Sample metrics defintion file:  aliyun_metrics_SLB.json
```json
{
    "Service": "Aliyun.SLB",
    "Namespace": "acs_slb_dashboard",
    "Action": "DescribeMetricLast",
    "Metrics": [
        {
            "MetricName": "ActiveConnection"
        },
        {
            "MetricName": "DropConnection"
        },
        {
            "MetricName": "DropPacketRX"
        },
        {
            "MetricName": "DropPacketTX"
        }
    ]
}
```

####  Rate Throttle support 
- Individual API level request rate throttling `async_rate` when `run_async` is true

```yaml
      apis:
        - event_type: myEvent
....
          run_async: true
          async_rate: 20
```
- Flex level rate throttle `async_rate` flag or env variable `ASYNC_RATE` for multiple configs concurrent execution scenario
`./nri-flex --async_rate 10  --config_file <your Flex integration yml> -pretty` 

#### Fixed racing condition with storing cache data  in `run_async` 
- Added an Mutex lock to prevent the concurrent map RW access

