### PR TITLE
added linux uptime in seconds. This helps to alert on unexpected reboots

### DIFF
--- a/examples/linux/linux-uptime-seconds.yml
+++ b/examples/linux/linux-uptime-seconds.yml
@@ -1,0 +1,14 @@
+# Flex integration to get uptime of Linux systems
+# How it works: We grab two values from /proc/uptime. 1. Uptime in secs 2. Seconds idle of all cores
+integrations: 
+  - name: nri-flex 
+    config:
+      name: linuxUptime 
+      apis:
+        - name: linuxUptimeSeconds # Event type will be linuxUptimeSecondsSample
+          commands: 
+            - run: cat /proc/uptime | awk  '{print $0}' 
+              split: horizontal
+              set_header: [secondsUptime, secondsIdleCores]
+              regex_match: true 
+              split_by: (.*)\s+(.*)


### PR DESCRIPTION
Added a new Flex config - linux-uptime-seconds. This was used in a scenario where sys admins wanted to know the number of seconds that Linux hosts were up. If they were below a certain threshold, it meant that the host had rebooted unexpectedly and  the admins wanted to be notified of it.