### PR TITLE
doc: added timeout and assert errors examples

### DIFF
--- a/build/compile.mk
+++ b/build/compile.mk
@@ -85,3 +85,14 @@ compile-windows32: deps-only
 		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
 		GOARCH=386 CGO_ENABLED=1 GOOS=windows $(GO_CMD) build -ldflags="$(LDFLAGS)" -o $$OUTPUT_FILE $$BUILD_FILES ; \
 	done
+
+.PHONY: compile-for-debug-linux
+compile-for-debug-linux: deps-only
+	@echo "=== $(PROJECT_NAME) === [ compile-for-debug-linux    ]: building commands:"
+	@mkdir -p $(BUILD_DIR)/linux
+	@for b in $(BINS); do \
+		OUTPUT_FILE="$(BUILD_DIR)/linux/$$b" ; \
+		echo "=== $(PROJECT_NAME) === [ compile-for-debug-linux    ]:     $$OUTPUT_FILE"; \
+		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
+		GOOS=linux $(GO_CMD) build -gcflags 'all=-N -l' -o $$OUTPUT_FILE $$BUILD_FILES ; \
+	done

--- a/docs/apis/commands.md
+++ b/docs/apis/commands.md
@@ -247,7 +247,7 @@ Add an assert block with a nested variable of `match` and/or `not_match`.
 Note both options use regex.
 
 ```yml
-#### Command output must contain the string "hi" - this will continue
+#### Command output must contain the string "hi" - this will returned in the payload
 integrations:
   - name: nri-flex
     config:
@@ -262,7 +262,7 @@ integrations:
 ```
 
 ```yml
-#### Command output must contain the string "foo" - this will NOT continue!
+#### Command output must contain the string "foo" - this will be discarded and not added to the payload
 integrations:
   - name: nri-flex
     config:
@@ -277,7 +277,7 @@ integrations:
 ```
 
 ```yml
-#### Command output must contain the string "hi" and not contain the string "foo - this will continue
+#### Command output must contain the string "hi" and not contain the string "foo - this will be added to the payload
 integrations:
   - name: nri-flex
     config:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -187,6 +187,84 @@ The next JSON object(s) will represent the output of `nri-flex` executing the su
 
 The last major section shows the `flexStatusSample` event. This is a heartbeat event that is sent along with every successful execution of `nri-flex` and can be used to evaluate whether a problem lies in your config, or with the Flex binary itself.
 
+#### Timeout error
+When timeout is reached Flex ignores the output and returns an error. Note that Flex waits for the command to stop by itself.
+Example:
+```yaml
+integrations:
+  - name: nri-flex
+    config:
+      name: Timeout
+      apis:
+        - name: Timeout
+          commands:
+            - run: echo "key:5" && sleep 2
+              timeout: 1000
+              set_header: [key]
+              split_by: ":"
+```
+
+Payload:
+```json
+{
+  "name": "com.newrelic.nri-flex",
+  "protocol_version": "3",
+  "integration_version": "1.4.1",
+  "data": [
+    {
+      "metrics": [
+        {
+          "context_error": "context deadline exceeded",
+          "error": "signal: killed",
+          "error_exec": "echo \"key:5\" \u0026\u0026 sleep 2",
+          "error_msg": "key:5\n",
+          "event_type": "TimeoutSample",
+          "integration_name": "com.newrelic.nri-flex",
+          "integration_version": "1.4.1"
+        }
+      ],
+      "inventory": {},
+      "events": []
+    }
+  ]
+}
+```
+If `verbose` is enabled, error will be logged too:
+```
+DEBU[0002] command: failed context_err="context deadline exceeded" err="signal: killed" exec="echo \"key:5\" && sleep 2" suggestion="if you are handling this error case, ignore"
+```
+
+#### Assertion rule
+Assertion rules will filter output based on regular expressions. When the output doesn't match the regular expression, this will
+be ignored **and no error** will be returned. If `verbose` mode is enabled, a log line will be produced when data is discarded.
+
+Example:
+```yaml
+
+integrations:
+
+  - name: nri-flex
+    config:
+      name: Assertion
+      apis:
+        - name: Assertion
+          commands:
+            - run: echo "key:not a number"
+              set_header: [key]
+              split_by: ":"
+              assert:
+                match: \d
+```
+If verbose is enabled, error will be logged:
+```
+...
+DEBU[0000] commands: assertion failed will not process   exe="echo \"key:not a number\"" name=Assertion
+...
+
+```
+
+More information about assertion can be found in [command docs](apis/commands.md#assert-output-exists-before-processing)
+
 ## Common issues
 
 Flex is pretty forgiving, but there may be times that the data you aimed at capturing won't show up in New Relic. There may be several reasons to this. Here are the most common, by category.


### PR DESCRIPTION
* Added make target to compile for debugging in linux.
* Added documentation and examples for timeout and assertion errors.