### PR TITLE
Update ebpf-tcplife.yml

### DIFF
--- a/examples/linux/ebpf-tcplife.yml
+++ b/examples/linux/ebpf-tcplife.yml
@@ -14,7 +14,7 @@ integrations:
               row_start: 3
               split: horizontal
               regex_match: true
-              split_by: (\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+)
+              split_by: (\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+),(\S+)
               set_header:
                 [
                   time,


### PR DESCRIPTION
split has 11 "(\S+)"  but headers have 12. I have added one more ",(\S+)" to make it full. 