### PR TITLE
URL checking example using curl

### DIFF
--- a/examples/linux/urlcheck.json
+++ b/examples/linux/urlcheck.json
@@ -1,0 +1,4 @@
+[
+  {"url":"https://www.newrelic.com"},
+  {"url":"https://developer.newrelic.com"}
+]

--- a/examples/linux/urlcheck.yml
+++ b/examples/linux/urlcheck.yml
@@ -1,0 +1,15 @@
+# "run" script is returning 3 tilda separated values
+# field names are specified by the set_header option
+# note this integration leverages the lookupfile "urlcheck.json"
+integrations:
+  - name: nri-flex
+    config:
+      name: URLCheck
+      lookup_file: /etc/newrelic-infra/integrations.d/urlcheck.json
+      apis:
+        - event_type: URLCheck
+          commands:
+            - run: printf "${lf:url}~$(curl --connect-timeout 5 -s -o /dev/null -I -w "%{http_code}~%{time_total}" ${lf:url})"
+              split_by: "~"
+              split: horizontal
+              set_header: [urlcheck.targetURL,urlcheck.httpResponseCode,urlcheck.totalTimeSec]


### PR DESCRIPTION
This example showcases a http-layer test with the intent of checking web endpoints on localhost.  The associated urlcheck.json has public web endpoints that should be replaced with localhost endpoints.