### PR TITLE
Added new Windows examples

### DIFF
--- a/examples/windows/windows-netstat.yml
+++ b/examples/windows/windows-netstat.yml
@@ -1,0 +1,16 @@
+# Windows Netstat
+integrations:
+  - name: nri-flex
+    interval: 60s
+    config:
+      name: winNetstat
+      apis:
+        - event_type: winNetstat
+          shell: powershell
+          commands:
+            - run: netstat -ano
+              split: horizontal
+              set_header: [proto, localAddress, foreignAddress, state, processId]
+              regex_match: true
+              row_start: 1
+              split_by: \s+(\w+)\s+(\S+)\s+(\S+)\s+(\w+|\s+)\s+(\d+)

--- a/examples/windows/windows-ps-processhandles.yml
+++ b/examples/windows/windows-ps-processhandles.yml
@@ -1,0 +1,11 @@
+# Windows Process Handles
+integrations:
+  - name: nri-flex
+    interval: 60s
+    config:
+      name: winProcessHandles
+      apis:
+        - event_type: winProcessHandles
+          shell: powershell
+          commands:
+            - run: Get-Process | Select-Object -Property ProcessName, Id, HandleCount | ConvertTo-Json


### PR DESCRIPTION
Added new Windows examples:
- `windows-netstat.yml` to call `netstat -ano` and send results to New Relic: useful for troubleshooting port exhaustion
- `windows-ps-processhandles.yml` to call `Get-Process` and send results to New Relic: useful for troubleshooting handle leaks