### PR TITLE
Flex integration for Okla speedtest cli (JSON output)

### DIFF
--- a/okla-speedtest.yml
+++ b/okla-speedtest.yml
@@ -1,0 +1,17 @@
+integrations:
+  - name: nri-flex
+    timeout: 5m
+    config:
+      interval: 120s
+      name: linuxspeedtest 
+      apis:
+        - name: speedtest
+          commands:
+            - run: sudo speedtest --accept-license -f json
+              timeout: 300000
+          remove_keys:
+            - timestamp
+
+# this flex integrations presumes you've installed the OKLA speedtest command line utility
+# https://www.speedtest.net/apps/cli
+# also make sure you update the  "run: sudo speedtest" command with the path to the utility


### PR DESCRIPTION
This flex integration takes JSON the output from okla's speedtest CLI utility and imports it into your New Relic dashboard. 

Note that the YML file requires you to first install the OKLA speedtest command line utility (from  https://www.speedtest.net/apps/cli).

Be sure to update the YML file's "run: sudo speedtest" command with the path to the utility.
