### PR TITLE
okla speedtest metrics using the JSON output

### DIFF
--- a/examples/linux/okla-speedtest.yml
+++ b/examples/linux/okla-speedtest.yml
@@ -3,7 +3,6 @@ integrations:
     timeout: 5m
     interval: 1h
     config:
-      
       name: linuxspeedtest 
       apis:
         - name: speedtest

--- a/examples/linux/okla-speedtest.yml
+++ b/examples/linux/okla-speedtest.yml
@@ -1,13 +1,14 @@
 integrations:
   - name: nri-flex
     timeout: 5m
+    interval: 1h
     config:
-      interval: 120s
+      
       name: linuxspeedtest 
       apis:
         - name: speedtest
           commands:
-            - run: sudo speedtest --accept-license -f json
+            - run: speedtest --accept-license -f json
               timeout: 300000
           remove_keys:
             - timestamp

--- a/examples/linux/okla-speedtest.yml
+++ b/examples/linux/okla-speedtest.yml
@@ -1,0 +1,17 @@
+integrations:
+  - name: nri-flex
+    timeout: 5m
+    config:
+      interval: 120s
+      name: linuxspeedtest 
+      apis:
+        - name: speedtest
+          commands:
+            - run: sudo speedtest --accept-license -f json
+              timeout: 300000
+          remove_keys:
+            - timestamp
+
+# this flex integrations presumes you've installed the OKLA speedtest command line utility
+# https://www.speedtest.net/apps/cli
+# also make sure you update the  "run: sudo speedtest" command with the path to the utility


### PR DESCRIPTION
This integrates internet speed metrics coming out of the Okla speedtest utility (which needs to be running locally on the target system) into New Relic, which can then be added to dashboards. 