### PR TITLE
feat: support aws ssm parameter secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ LATEST
 dist
 .vscode
 .envrc
+.dccache
 
 envvars
 flexConfigs/

--- a/docs/development.md
+++ b/docs/development.md
@@ -87,6 +87,7 @@ Once you've tested your configuration and you're ready to use in production, you
 - [dep](https://github.com/golang/dep) - Dependency management tool (if not using `go mod`, which we advise you to use)
 - [golangci-lint v1.22.2](https://github.com/golangci/golangci-lint)
 - Docker Compose (for integration tests)
+- wget
 
 ### <a name='Setup'></a>Setup
 
@@ -101,7 +102,7 @@ cd ${GOPATH}/src/github.com/newrelic/nri-flex
 make clean
 
 # Download all required libraries
-make dep
+make deps
 ```
 
 ### <a name='Build'></a>Build


### PR DESCRIPTION
Implementation of [NEWRELIC-5592](https://issues.newrelic.com/browse/NEWRELIC-5592)

A POC for AWS SSM support, following how AWS KMS was implemented.

### enhancement

- Support fetching AWS SSM parameters for integration variables

### use case

AWS SSM is used much a much more cost-effective and flexible solution to store parameters as opposed to AWS KMS. This would help those who would like to move integrations from AWS into nri-flex but want to keep secrets/parameters in AWS. Those running the infrastructure agent in an EKS cluster can configure service accounts with access to parameters, simplifying access.

### example

```yaml
variables:
  tag_name:
    aws-ssm:
      region: ap-southeast-2
      type: plain
      data: /path/in/ssm

integrations:
  - name: nri-flex
     config:
       name: AwsCostExplorerIntegration
       apis:
         - event_type: AwsCostExplorerSample
            commands:
              - run: |
                   aws ce get-cost-and-usage \
                   --group-by Type=TAG,Key="${tag_name}"
                   ...
```

### todo

- [ ] tests
- [ ] documentation
- [ ] how to consume parameter path?
- [ ] how to specify whether or not to decrypt the parameter value