### PR TITLE
|NEWRELIC-6016 fix: allow multiple values in lookup

### DIFF
--- a/internal/config/fetch.go
+++ b/internal/config/fetch.go
@@ -16,6 +16,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+var lookupsRegex = regexp.MustCompile(`\${lookup\.([^:]+):([^}]+)}`)
+
 // FetchData fetches data from various inputs
 // Also handles paginated responses for HTTP requests (tested against NR APIs)
 func FetchData(apiNo int, yml *load.Config, samplesToMerge *load.SamplesToMerge) []interface{} {
@@ -256,10 +258,14 @@ func loopLookups(loopNo int, sliceIndexes []int, sliceLookups [][]string, combin
 	}
 }
 
+func findLookups(content string) [][]string {
+	return lookupsRegex.FindAllStringSubmatch(content, -1)
+}
+
 // automaticLookup check existing samples to create lookups
 func automaticLookup(tmpCfgStr string, cfg *load.Config, apiNo int) []string {
 	var newAPIs []string
-	lookupsFound := regexp.MustCompile(`\${lookup\.(.+):(.+)}`).FindAllStringSubmatch(tmpCfgStr, -1)
+	lookupsFound := findLookups(tmpCfgStr)
 	// if no lookups, do not continue running the processor
 	if len(lookupsFound) == 0 {
 		return []string{}

--- a/internal/config/fetch_test.go
+++ b/internal/config/fetch_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDimensionalLookup(t *testing.T) {
 	lookupStore := map[string][]string{}
@@ -65,5 +69,49 @@ func TestDimensionalLookup(t *testing.T) {
 				t.Errorf("want: %v, got: %v", expected[i][z], comboKey)
 			}
 		}
+	}
+}
+
+func Test_findLookups(t *testing.T) {
+	testCases := []struct {
+		name            string
+		content         string
+		expectedLookups [][]string
+	}{
+		{
+			name:            "no lookups",
+			content:         "",
+			expectedLookups: nil,
+		},
+		{
+			name:    "one lookup",
+			content: "http://some-other-service.com/users/${lookup.postSample:userId}",
+			expectedLookups: [][]string{
+				{
+					"${lookup.postSample:userId}", "postSample", "userId",
+				},
+			},
+		},
+		{
+			name:    "multiple lookup",
+			content: "http://some-other-service.com/users/${lookup.postSample:userId}_${lookup.postSample:name}__${lookup.anotherSample:anotherValue}",
+			expectedLookups: [][]string{
+				{
+					"${lookup.postSample:userId}", "postSample", "userId",
+				},
+				{
+					"${lookup.postSample:name}", "postSample", "name",
+				},
+				{
+					"${lookup.anotherSample:anotherValue}", "anotherSample", "anotherValue",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedLookups, findLookups(tc.content))
+		})
 	}
 }

--- a/test/testbed/scenarios/fixtures/file_api.go
+++ b/test/testbed/scenarios/fixtures/file_api.go
@@ -166,4 +166,21 @@ apis:
 `,
 		ExpectedStdout: `{"name":"com.newrelic.nri-flex","protocol_version":"3","integration_version":"Unknown-SNAPSHOT","data":[{"metrics":[{"HOSTNAME":"7605f6bec898","HOST_ID":0,"PERCENT_USED":0,"TIMESTAMP":1582159853733,"event_type":"voltdb","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT"},{"HOSTNAME":"067ea6fc4c22","HOST_ID":2,"PERCENT_USED":0,"TIMESTAMP":1582159853733,"event_type":"voltdb","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT"},{"HOSTNAME":"62a10d3f45e3","HOST_ID":1,"PERCENT_USED":0,"TIMESTAMP":1582159853733,"event_type":"voltdb","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT"},{"event_type":"flexStatusSample","flex.Hostname":"0e0a965295ba","flex.IntegrationVersion":"Unknown-SNAPSHOT","flex.counter.ConfigsProcessed":1,"flex.counter.EventCount":3,"flex.counter.EventDropCount":0,"flex.counter.voltdb":3,"flex.time.elapsedMs":45,"flex.time.endMs":1654776591203,"flex.time.startMs":1654776591158}],"inventory":{},"events":[]}]}`,
 	},
+	{
+		Name:        "Use lookup",
+		FileContent: `[{"brand":"honda","car":"civic"},{"brand":"toyota","car":"supra"},{"brand":"mistsubishi","car":"lancer"}]`,
+		Config: `
+name: LookUps
+apis:
+  - name: read
+    event_type: read
+    file: FILE_PATH
+
+  - name: world
+    commands:
+      - run: echo "${lookup.read:brand}:${lookup.read:car}"
+        split_by: ":"
+`,
+		ExpectedStdout: `{"name":"com.newrelic.nri-flex","protocol_version":"3","integration_version":"Unknown-SNAPSHOT","data":[{"metrics":[{"brand":"honda","car":"civic","event_type":"read","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT"},{"brand":"toyota","car":"supra","event_type":"read","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT"},{"brand":"mistsubishi","car":"lancer","event_type":"read","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT"},{"event_type":"worldSample","flex.commandTimeMs":3,"honda":"civic","integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT"},{"event_type":"worldSample","flex.commandTimeMs":0,"integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT","toyota":"supra"},{"event_type":"worldSample","flex.commandTimeMs":0,"integration_name":"com.newrelic.nri-flex","integration_version":"Unknown-SNAPSHOT","mistsubishi":"lancer"},{"event_type":"flexStatusSample","flex.Hostname":"ubuntu-2004-vm","flex.IntegrationVersion":"Unknown-SNAPSHOT","flex.counter.ConfigsProcessed":1,"flex.counter.EventCount":6,"flex.counter.EventDropCount":0,"flex.counter.read":3,"flex.counter.worldSample":3,"flex.time.elapsedMs":22,"flex.time.endMs":1672415688172,"flex.time.startMs":1672415688150}],"inventory":{},"events":[]}]}`,
+	},
 }


### PR DESCRIPTION
Allow accessing multiple values from lookup output

Fixes https://github.com/newrelic/nri-flex/issues/402