### PR TITLE
[Chore] fix timestamp_conversion example

### DIFF
--- a/docs/basics/functions.md
+++ b/docs/basics/functions.md
@@ -1796,7 +1796,7 @@ apis:
     url: http://127.0.0.1:8887/simpletime.json
     timestamp_conversion:
       endtime: DATE::RFC3339      
-      started_at: TIMESTAMP::2006-01-02T03:04
+      started_at: TIMESTAMP::RFC3339
 ```
 
 Which would return something similar to:


### PR DESCRIPTION
Fix conversion to timestamp example (see https://github.com/newrelic/nri-flex/blob/62d2b4ea14530b6ba7821cc762ec21fd3b3fc199/internal/processor/create.go#L73)

Tested the updated version (from the code example linked above) and it works for me.