### PR TITLE
Bump SDK to 3.8.2 and allow TempDir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/itchyny/gojq v0.12.12
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/lib/pq v1.10.9
-	github.com/newrelic/infra-integrations-sdk v3.2.0+incompatible
+	github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible
 	github.com/parnurzeal/gorequest v0.2.15
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3P
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/moul/http2curl v1.0.0 h1:dRMWoAtb+ePxMlLkrCbAqh4TlPHXvoGUSQ323/9Zahs=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
-github.com/newrelic/infra-integrations-sdk v3.2.0+incompatible h1:AKmduPZE9QgBmyTHIE9PH4Z0jUKU71r9PI9AObJDFbA=
-github.com/newrelic/infra-integrations-sdk v3.2.0+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
+github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible h1:Ktcm1aPAl7CW3o+FXAIKJ+jygWVXDXaUIWFyf2CXQTk=
+github.com/newrelic/infra-integrations-sdk v3.8.2+incompatible/go.mod h1:tMUHRMq6mJS0YyBnbWrTXAnREnQqC1AGO6Lu45u5xAM=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=

--- a/internal/outputs/infra.go
+++ b/internal/outputs/infra.go
@@ -76,5 +76,8 @@ func createStorer() (persist.Storer, error) {
 	if os.Getenv("VERBOSE") == "true" || os.Getenv("VERBOSE") == "1" {
 		fmt.Fprintf(os.Stderr, "custom storer name: %s and TTL: %s\n", storerName, ttl)
 	}
-	return persist.NewFileStore(persist.DefaultPath(storerName), load.Logrus, ttl)
+
+	tempDir := os.Getenv("TEMP_DIR")
+
+	return persist.NewFileStore(persist.TmpPath(tempDir, storerName), load.Logrus, ttl)
 }

--- a/internal/processor/create.go
+++ b/internal/processor/create.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/data/event"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
@@ -276,7 +277,7 @@ func RunSampleRenamer(renameSamples map[string]string, currentSample *map[string
 	}
 }
 
-//Save samples to a JSON file
+// Save samples to a JSON file
 func saveSamples(samples []interface{}, outputPath string) {
 	outputs.StoreJSON(samples, outputPath)
 }
@@ -484,12 +485,12 @@ func AutoSetStandard(currentSample *map[string]interface{}, api *load.API, worki
 	if len(api.MetricParser.Metrics) > 0 {
 		useDefaultNamespace := false
 		if api.MetricParser.Namespace.CustomAttr != "" {
-			metricSet = workingEntity.NewMetricSet(eventType, metric.Attr("namespace", api.MetricParser.Namespace.CustomAttr))
+			metricSet = workingEntity.NewMetricSet(eventType, attribute.Attr("namespace", api.MetricParser.Namespace.CustomAttr))
 		} else if len(api.MetricParser.Namespace.ExistingAttr) == 1 {
 			nsKey := api.MetricParser.Namespace.ExistingAttr[0]
 			switch nsVal := (*currentSample)[nsKey].(type) {
 			case string:
-				metricSet = workingEntity.NewMetricSet(eventType, metric.Attr(nsKey, nsVal))
+				metricSet = workingEntity.NewMetricSet(eventType, attribute.Attr(nsKey, nsVal))
 				delete((*currentSample), nsKey) // can delete from sample as already set via namespace key
 			default:
 				useDefaultNamespace = true
@@ -508,7 +509,7 @@ func AutoSetStandard(currentSample *map[string]interface{}, api *load.API, worki
 				}
 			}
 			if finalValue != "" {
-				metricSet = workingEntity.NewMetricSet(eventType, metric.Attr("namespace", finalValue))
+				metricSet = workingEntity.NewMetricSet(eventType, attribute.Attr("namespace", finalValue))
 			} else {
 				useDefaultNamespace = true
 			}
@@ -516,7 +517,7 @@ func AutoSetStandard(currentSample *map[string]interface{}, api *load.API, worki
 
 		if useDefaultNamespace {
 			load.Logrus.Debugf("flex: defaulting a namespace for:%v", api.Name)
-			metricSet = workingEntity.NewMetricSet(eventType, metric.Attr("namespace", api.Name))
+			metricSet = workingEntity.NewMetricSet(eventType, attribute.Attr("namespace", api.Name))
 		}
 	} else {
 		metricSet = workingEntity.NewMetricSet(eventType)


### PR DESCRIPTION
- Bump SDK to 3.8.2 and allow TempDir modification for caches
- Adapt newMetricSet add namespace Attributes