### PR TITLE
NR-291019 add fips compliant package builds

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,18 +28,16 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
       - name: Install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Run unit tests
         run:  make ci/test
-      - name: Convert coverage.out to lcov.info
-        run: make ci/convert-coverage
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          path-to-lcov: lcov.info
+          path-to-lcov: ./coverage.out
           flag-name: run-linux
           parallel: true
 
@@ -82,7 +80,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: run unit tests
@@ -119,7 +117,7 @@ jobs:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Run e2e tests
@@ -131,7 +129,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,16 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
       - name: Install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Run unit tests
         run:  make ci/test
-      - name: Convert coverage.out to lcov.info
-        run: make ci/convert-coverage
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          path-to-lcov: lcov.info
+          path-to-lcov: ./coverage.out
           flag-name: run-linux
           parallel: true
 
@@ -79,7 +77,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: install go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: run unit tests
@@ -120,7 +118,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,44 @@
-ARG GO_VERSION=1.22
+# Use Ubuntu 16.04 as the base image
+FROM ubuntu:16.04
 
-FROM golang:$GO_VERSION
+# Define Go version
+ARG GO_VERSION=1.22
+ARG ARCH='amd64'
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    expect \
+    git \
+    tar \
+    gcc \
+    jq \
+    g++ \
+    gnupg2 \
+    gnupg-agent \
+    debsigs \
+    rpm \
+    build-essential \
+    software-properties-common \
+    python-software-properties \
+    gcc-arm-linux-gnueabi \
+    dpkg-sig \
+    gcc-aarch64-linux-gnu
+
+# Install Go
+# It tries to get the latest patch version of Go that matches the version specified in the Makefile
+# It can be simplified once we have Renovatebot support for this repo
+RUN FULL_GO_VERSION=$(curl -s "https://go.dev/dl/?mode=json" | \
+    jq -r --arg VERSION "${GO_VERSION}" \
+    '[.[] | select(.version | test("^go\($VERSION)\\."))] | .[0].version') && \
+    curl -sSL https://golang.org/dl/${FULL_GO_VERSION}.linux-${ARCH}.tar.gz -o ${FULL_GO_VERSION}.linux-${ARCH}.tar.gz && \
+    tar -C /usr/local -xzf ${FULL_GO_VERSION}.linux-${ARCH}.tar.gz && \
+    rm ${FULL_GO_VERSION}.linux-${ARCH}.tar.gz
+
+# Set Go environment variables
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOPATH="/go"
 
 WORKDIR /app
 
@@ -9,7 +47,10 @@ COPY tools /app/tools
 
 COPY go.mod go.sum Makefile /app/
 
+# Optional: Set Go environment flags
 ENV GOFLAGS="-buildvcs=false"
+
+# Optional: Configure git
 RUN git config --global --add safe.directory /go/src/github.com/newrelic/nri-flex
 
 RUN make deps

--- a/build/compile.mk
+++ b/build/compile.mk
@@ -19,7 +19,7 @@ compile-only: deps-only
 	@mkdir -p $(BUILD_DIR)/$(GOOS)
 	@for b in $(BINS); do \
 		echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)$(GOOS)/$$b"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
+		BUILD_FILES="$(SRCDIR)/cmd/..." ; \
 		$(GO_CMD) build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(GOOS)/$$b $$BUILD_FILES ; \
 	done
 
@@ -38,10 +38,21 @@ compile-linux: deps-only
 	@echo "=== $(PROJECT_NAME) === [ compile-linux    ]: building commands:"
 	@mkdir -p $(BUILD_DIR)/linux
 	@for b in $(BINS); do \
-		OUTPUT_FILE="$(BUILD_DIR)linux/$$b" ; \
+		OUTPUT_FILE="$(BUILD_DIR)/linux/$$b" ; \
 		echo "=== $(PROJECT_NAME) === [ compile-linux    ]:     $$OUTPUT_FILE"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
+		BUILD_FILES="$(SRCDIR)/cmd/..." ; \
 		GOOS=linux $(GO_CMD) build -ldflags="$(LDFLAGS)" -o $$OUTPUT_FILE $$BUILD_FILES ; \
+	done
+
+.PHONY: compile-linux-fips
+compile-linux-fips: deps-only
+	@echo "=== $(PROJECT_NAME) === [ compile-linux-fips    ]: building commands:"
+	@mkdir -p $(BUILD_DIR)/linux-fips
+	@for b in $(BINS); do \
+		OUTPUT_FILE="$(BUILD_DIR)/linux-fips/$$b" ; \
+		echo "=== $(PROJECT_NAME) === [ compile-linux-fips    ]:     $$OUTPUT_FILE"; \
+		BUILD_FILES="$(SRCDIR)/cmd/..." ; \
+		GOOS=linux GOFIPS=1 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOEXPERIMENT=boringcrypto $(GO_CMD) build -tags fips -ldflags="$(LDFLAGS)" -o $$OUTPUT_FILE $$BUILD_FILES ; \
 	done
 
 .PHONY: build-darwin
@@ -52,9 +63,9 @@ compile-darwin: deps-only
 	@echo "=== $(PROJECT_NAME) === [ compile-darwin   ]: building commands:"
 	@mkdir -p $(BUILD_DIR)/darwin
 	@for b in $(BINS); do \
-		OUTPUT_FILE="$(BUILD_DIR)darwin/$$b" ; \
+		OUTPUT_FILE="$(BUILD_DIR)/darwin/$$b" ; \
 		echo "=== $(PROJECT_NAME) === [ compile-darwin   ]:     $$OUTPUT_FILE"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
+		BUILD_FILES="$(SRCDIR)/cmd/..." ; \
 		GOOS=darwin $(GO_CMD) build -ldflags="$(LDFLAGS)" -o $$OUTPUT_FILE $$BUILD_FILES ; \
 	done
 
@@ -66,9 +77,9 @@ compile-windows: deps-only
 	@echo "=== $(PROJECT_NAME) === [ compile-windows  ]: building commands:"
 	@mkdir -p $(BUILD_DIR)/windows
 	@for b in $(BINS); do \
-		OUTPUT_FILE="$(BUILD_DIR)windows/$$b.exe" ; \
+		OUTPUT_FILE="$(BUILD_DIR)/windows/$$b.exe" ; \
 		echo "=== $(PROJECT_NAME) === [ compile-windows  ]:     $$OUTPUT_FILE"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
+		BUILD_FILES="$(SRCDIR)/cmd/..." ; \
 		GOOS=windows $(GO_CMD) build -ldflags="$(LDFLAGS)" -o $$OUTPUT_FILE $$BUILD_FILES ; \
 	done
 
@@ -80,9 +91,9 @@ compile-windows32: deps-only
 	@echo "=== $(PROJECT_NAME) === [ compile-windows  ]: building commands:"
 	@mkdir -p $(BUILD_DIR)/windows
 	@for b in $(BINS); do \
-		OUTPUT_FILE="$(BUILD_DIR)windows/$$b.exe" ; \
+		OUTPUT_FILE="$(BUILD_DIR)/windows/$$b.exe" ; \
 		echo "=== $(PROJECT_NAME) === [ compile-windows  ]:     $$OUTPUT_FILE"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
+		BUILD_FILES="$(SRCDIR)/cmd/..." ; \
 		GOARCH=386 CGO_ENABLED=1 GOOS=windows $(GO_CMD) build -ldflags="$(LDFLAGS)" -o $$OUTPUT_FILE $$BUILD_FILES ; \
 	done
 
@@ -93,6 +104,6 @@ compile-for-debug-linux: deps-only
 	@for b in $(BINS); do \
 		OUTPUT_FILE="$(BUILD_DIR)/linux/$$b" ; \
 		echo "=== $(PROJECT_NAME) === [ compile-for-debug-linux    ]:     $$OUTPUT_FILE"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
+		BUILD_FILES="$(SRCDIR)/cmd/..." ; \
 		GOOS=linux $(GO_CMD) build -gcflags 'all=-N -l' -o $$OUTPUT_FILE $$BUILD_FILES ; \
 	done

--- a/build/goreleaser.yml
+++ b/build/goreleaser.yml
@@ -20,12 +20,30 @@ builds:
         {{- if eq .Os "linux" -}}
         CGO_ENABLED=0
         {{- end }}
-    # overrides:
-    #   - goos: linux
-    #     env:
-    #     - CGO_ENABLED=0
+  - id: nri-flex-fips
+    main: ./cmd/nri-flex/
+    binary: nri-flex
+    ldflags:
+      - -s -w -X github.com/newrelic/nri-flex/internal/load.IntegrationVersion={{.Version}}
+    goos:
+    - linux
+    goarch:
+    - amd64
+    - arm64
+    env:
+      - CGO_ENABLED=1
+      - GOEXPERIMENT=boringcrypto
+      - >-
+        {{- if eq .Arch "arm64" -}}
+        CC=aarch64-linux-gnu-gcc
+        {{- end }}
+    tags:
+      - fips
 archives:
-  - files:
+  - id: nri-flex
+    builds:
+      - nri-flex
+    files:
       - LICENSE
       - README.md
       - CHANGELOG.md
@@ -34,6 +52,15 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+  - id: nri-flex-fips
+    builds:
+      - nri-flex-fips
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+      - examples/*
+    name_template:  "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_fips" # Used to change `armv6` to `arm`
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/cmd/nri-flex/fips.go
+++ b/cmd/nri-flex/fips.go
@@ -1,0 +1,11 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build fips
+// +build fips
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,6 @@ github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
-github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
 github.com/pkg/sftp v1.13.7 h1:uv+I3nNJvlKZIQGSr8JVQLNHFU9YhhNpvC14Y6KgmSM=
 github.com/pkg/sftp v1.13.7/go.mod h1:KMKI0t3T6hfA+lTR/ssZdunHo+uwq7ghoN09/FSu3DY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -200,10 +198,6 @@ github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFt
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
-github.com/sijms/go-ora/v2 v2.8.19 h1:7LoKZatDYGi18mkpQTR/gQvG9yOdtc7hPAex96Bqisc=
-github.com/sijms/go-ora/v2 v2.8.19/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
-github.com/sijms/go-ora/v2 v2.8.20 h1:VeJ97pwuIesYCeMgFmw60IiYZDst98annQCtxbLP7qU=
-github.com/sijms/go-ora/v2 v2.8.20/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sijms/go-ora/v2 v2.8.22 h1:3ABgRzVKxS439cEgSLjFKutIwOyhnyi4oOSBywEdOlU=
 github.com/sijms/go-ora/v2 v2.8.22/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -266,7 +260,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
@@ -289,7 +282,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
@@ -319,7 +311,6 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -331,7 +322,6 @@ golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=


### PR DESCRIPTION
## What?
Adds compilation and packaging of FIPS compliant packages using `boringcrypto`
## Why?
Many customers can only use FIPS compliant packages in their environments
## How?
* use a new Dockerfile to build FIPS and non-FIPS packages
* update goreleaser config to build and package FIPS compliant packages in addition to the normal packages
* Update release workflow to use the same format as infra-agent for coverage.

