### PR TITLE
Added patch to GoLang version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:16.04
 
 # Define Go version
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.22.9
 ARG ARCH='amd64'
 
 # Install dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-flex
 
-go 1.22
+go 1.22.9
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible


### PR DESCRIPTION
Added patch to the GoLang versions in `Docker` and `go.mod` files to ensure Renovate Auto merges PRs whenever a new GoLang patch version is released.