### PR TITLE
fix(fips): update fips archive name format

### DIFF
--- a/build/goreleaser.yml
+++ b/build/goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 project_name: nri-flex
 builds:
   - id: nri-flex
@@ -64,7 +65,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Version }}-snapshot"
+  version_template: "{{ .Version }}-snapshot"
 changelog:
   sort: asc
   filters:

--- a/build/goreleaser.yml
+++ b/build/goreleaser.yml
@@ -60,7 +60,7 @@ archives:
       - README.md
       - CHANGELOG.md
       - examples/*
-    name_template:  "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_fips" # Used to change `armv6` to `arm`
+    name_template:  "{{ .ProjectName }}-fips_{{ .Os }}_{{ .Version }}_{{ .Arch }}" # Used to change `armv6` to `arm`
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/build/release.mk
+++ b/build/release.mk
@@ -1,4 +1,4 @@
-GORELEASER_VERSION  ?= v1.19.2
+GORELEASER_VERSION  ?= v2.4.4
 GORELEASER_BIN      ?= $(CURDIR)/bin/goreleaser
 GORELEASER_CONFIG   ?= --config $(CURDIR)/build/goreleaser.yml
 PKG_FLAGS			?= --clean


### PR DESCRIPTION
To unify the naming format for archives and packages, updating `fips` archive names.
Also updated `goreleaser` as part of the same PR.