### PR TITLE
fix: database inputs are not cached

### DIFF
--- a/internal/config/fetch.go
+++ b/internal/config/fetch.go
@@ -87,7 +87,14 @@ func FetchData(apiNo int, yml *load.Config, samplesToMerge *load.SamplesToMerge)
 				yml.Datastore = map[string][]interface{}{}
 			}
 			yml.Datastore[api.File] = dataStore
-		}
+		} else if api.Database != "" && api.DBConn != "" {
+            if yml.Datastore == nil {
+                yml.Datastore = map[string][]interface{}{}
+            }
+            if api.Name != "" {
+                yml.Datastore[api.Name] = dataStore
+            }
+    	}
 
 		load.CacheStoreLock.Unlock()
 	}


### PR DESCRIPTION
Documented cache functionality should be available for all inputs.
However database inputs are currently being excluded.

Fix allows support for it.