### PR TITLE
chore: upgrade go version to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-flex
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-flex/tools
 
-go 1.25.9
+go 1.25.10
 require (
 	github.com/AlekSi/gocov-xml v1.2.0
 	github.com/axw/gocov v1.2.1


### PR DESCRIPTION
## Summary

Addresses [NR-564347](https://new-relic.atlassian.net/browse/NR-564347) — Trivy/Grype flag 11 CVEs per OHAI component (6 HIGH, 5 MEDIUM) resolved by upgrading to **Go 1.25.10** or 1.26.3.

Bumps both `go.mod` and `tools/go.mod` from 1.25.9 → 1.25.10. Mirrors the prior 1.25.8 → 1.25.9 bump (#631).

## Test plan

- [x] `go build ./...` — passes locally
- [x] `go test ./cmd/... ./internal/...` — all unit tests pass locally (Go 1.26.3 runtime)
- [ ] CI unit + integration tests on push

[NR-564347]: https://new-relic.atlassian.net/browse/NR-564347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ