### PR TITLE
fix: resolve CodeQL security issues

### DIFF
--- a/internal/aliyun/signer.go
+++ b/internal/aliyun/signer.go
@@ -52,7 +52,7 @@ func (s *Signer) Sign(r *http.Request) (string, error) {
 	paramsToSign.Add("Signature", signature)
 
 	signedURL = r.URL.Scheme + "://" + r.URL.Host + r.URL.Path + "?" + paramsToSign.Encode()
-	load.Logrus.Debugf("Aliyun Signer: SignedUrl: %v ", signedURL)
+	load.Logrus.Debug("Aliyun Signer: URL signed successfully")
 	return signedURL, nil
 }
 
@@ -71,8 +71,7 @@ func ShaHmac1(source, secret string) string {
 	signedBytes := hmac.Sum(nil)
 	signedString := base64.StdEncoding.EncodeToString(signedBytes)
 
-	load.Logrus.Debugf("Aliyun Signer: String to sign: %v", source)
-	load.Logrus.Debugf("Aliyun Signer: Signature: %v", signedString)
+	load.Logrus.Debug("Aliyun Signer: HMAC signature computed successfully")
 
 	return signedString
 }

--- a/internal/inputs/scp.go
+++ b/internal/inputs/scp.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/newrelic/nri-flex/internal/utils"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // RunScpWithTimeout performs scp with timeout to gather data from a remote file.
@@ -68,14 +71,19 @@ func getSSHConnection(yml *load.Config, api load.API) (*sftp.Client, error) {
 		return nil, err
 	}
 
+	hostKeyCallback, err := getHostKeyCallback(api.Scp.KnownHostsFile)
+	if err != nil {
+		return nil, fmt.Errorf("ssh: failed to set up host key verification: %v", err)
+	}
+
 	sshConfig := &ssh.ClientConfig{
 		User:            user,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         timeout,
 		Auth: []ssh.AuthMethod{
 			authMethod,
 		},
-	} // #nosec
+	}
 
 	sshConfig.SetDefaults()
 
@@ -90,6 +98,36 @@ func getSSHConnection(yml *load.Config, api load.API) (*sftp.Client, error) {
 		return nil, fmt.Errorf("ssh: failed to init sftp client, error: %v", err)
 	}
 	return client, nil
+}
+
+func getHostKeyCallback(knownHostsFile string) (ssh.HostKeyCallback, error) {
+	if knownHostsFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine home directory: %v", err)
+		}
+		knownHostsFile = filepath.Join(home, ".ssh", "known_hosts")
+	}
+
+	// If the known_hosts file doesn't exist, create it so knownhosts.New
+	// succeeds but rejects all unknown hosts (secure by default).
+	if _, err := os.Stat(knownHostsFile); os.IsNotExist(err) {
+		dir := filepath.Dir(knownHostsFile)
+		if mkErr := os.MkdirAll(dir, 0700); mkErr != nil {
+			return nil, fmt.Errorf("unable to create directory for known_hosts file %s: %v", knownHostsFile, mkErr)
+		}
+		f, createErr := os.OpenFile(knownHostsFile, os.O_CREATE|os.O_WRONLY, 0600)
+		if createErr != nil {
+			return nil, fmt.Errorf("unable to create known_hosts file %s: %v", knownHostsFile, createErr)
+		}
+		f.Close()
+	}
+
+	callback, err := knownhosts.New(knownHostsFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read known_hosts file %s: %v", knownHostsFile, err)
+	}
+	return callback, nil
 }
 
 func getAuthMethod(yml *load.Config, api load.API) (ssh.AuthMethod, error) {

--- a/internal/inputs/scp_test.go
+++ b/internal/inputs/scp_test.go
@@ -97,6 +97,9 @@ func TestGetSSHConnection(t *testing.T) {
 			"no route to host",
 			"network is unreachable",
 			"failed to connect to sftp host",
+			"knownhosts",
+			"host key verification",
+			"known_hosts",
 		}
 
 		errorMatched := false

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -498,13 +498,14 @@ type JMX struct {
 
 // SCP struct
 type SCP struct {
-	User       string `yaml:"user"`
-	Pass       string `yaml:"pass"`
-	Host       string `yaml:"host"`
-	Port       string `yaml:"port"`
-	RemoteFile string `yaml:"remote_file"`
-	Passphrase string `yaml:"pass_phrase"`
-	SSHPEMFile string `yaml:"ssh_pem_file"`
+	User           string `yaml:"user"`
+	Pass           string `yaml:"pass"`
+	Host           string `yaml:"host"`
+	Port           string `yaml:"port"`
+	RemoteFile     string `yaml:"remote_file"`
+	Passphrase     string `yaml:"pass_phrase"`
+	SSHPEMFile     string `yaml:"ssh_pem_file"`
+	KnownHostsFile string `yaml:"known_hosts_file"`
 }
 
 // HWSigner struct

--- a/internal/utils/simpleEncryt.go
+++ b/internal/utils/simpleEncryt.go
@@ -8,14 +8,14 @@ package utils
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/md5" // nolint
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"io"
 )
 
 func createHash(key string) string {
-	hasher := md5.New() // nolint
+	hasher := sha256.New()
 	hasher.Write([]byte(key))
 	return hex.EncodeToString(hasher.Sum(nil))
 }


### PR DESCRIPTION
## Summary
- Replace MD5 with SHA256 for encryption key derivation (`go/weak-sensitive-data-hashing`)
- Replace `ssh.InsecureIgnoreHostKey()` with `knownhosts` verification (`go/insecure-hostkeycallback`)
- Remove clear-text logging of credentials in Aliyun signer (`go/clear-text-logging`)

## Root Cause
CodeQL flagged three security issues:
1. **NR-560139**: `crypto/md5` used to derive AES keys in `simpleEncryt.go` — MD5 is cryptographically broken
2. **NR-560141**: `ssh.InsecureIgnoreHostKey()` in `scp.go` disables SSH host key verification, enabling MITM attacks
3. **NR-560142**: `signer.go` logs signed URLs, signing strings, and signatures containing AccessKeyId and secrets

## Breaking Changes
- `simpleEncryt.go`: SHA256 produces 32-byte keys (AES-256) vs MD5's 16-byte (AES-128). Previously encrypted data cannot be decrypted with the new key derivation.
- `scp.go`: SSH connections now require host keys in `~/.ssh/known_hosts` (or a file specified via `known_hosts_file` config option).

## Test plan
- [ ] Verify build passes (`go build ./...`)
- [ ] Verify existing tests pass (`go test ./...`)
- [ ] Confirm CodeQL alerts are resolved after merge

Resolves: [NR-560139](https://new-relic.atlassian.net/browse/NR-560139), [NR-560141](https://new-relic.atlassian.net/browse/NR-560141), [NR-560142](https://new-relic.atlassian.net/browse/NR-560142)

[NR-560139]: https://new-relic.atlassian.net/browse/NR-560139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ