### PR TITLE
fix: add security-events: write to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   security:


### PR DESCRIPTION
## Summary
- Add `security-events: write` permission to the security workflow
- Required by `reusable_security.yaml@v3` to upload SARIF results to GitHub security tab
- Without this, the workflow fails with: `The workflow is requesting 'security-events: write', but is only allowed 'security-events: none'`

## Test plan
- [ ] Verify security workflow passes after merge