### PR TITLE
fix: resolve CodeQL go/clear-text-logging in aliyun signer

### DIFF
--- a/internal/aliyun/signer.go
+++ b/internal/aliyun/signer.go
@@ -52,7 +52,7 @@ func (s *Signer) Sign(r *http.Request) (string, error) {
 	paramsToSign.Add("Signature", signature)
 
 	signedURL = r.URL.Scheme + "://" + r.URL.Host + r.URL.Path + "?" + paramsToSign.Encode()
-	load.Logrus.Debugf("Aliyun Signer: SignedUrl: %v ", signedURL)
+	load.Logrus.Debug("Aliyun Signer: URL signed successfully")
 	return signedURL, nil
 }
 
@@ -71,8 +71,7 @@ func ShaHmac1(source, secret string) string {
 	signedBytes := hmac.Sum(nil)
 	signedString := base64.StdEncoding.EncodeToString(signedBytes)
 
-	load.Logrus.Debugf("Aliyun Signer: String to sign: %v", source)
-	load.Logrus.Debugf("Aliyun Signer: Signature: %v", signedString)
+	load.Logrus.Debug("Aliyun Signer: HMAC signature computed successfully")
 
 	return signedString
 }

--- a/internal/runtime/flex.go
+++ b/internal/runtime/flex.go
@@ -159,7 +159,7 @@ func logEncryptPass() error {
 		return err
 	}
 	log.Infof("   encrypt_pass: %s", cleartext)
-	log.Infof("    pass_phrase: %s", load.Args.PassPhrase)
+	log.Info("    pass_phrase: [REDACTED]")
 	log.Infof(" encrypted pass: %x", cipherText)
 
 	return nil


### PR DESCRIPTION
## Summary
- Replace debug logs that printed signed URLs and HMAC signatures with generic success messages
- Avoids logging sensitive data (API signatures, signing strings)
- Resolves CodeQL alert `go/clear-text-logging` ([NR-560142](https://new-relic.atlassian.net/browse/NR-560142))

## Test plan
- [ ] Verify CI passes
- [ ] Confirm CodeQL alert auto-closes after merge

[NR-560142]: https://new-relic.atlassian.net/browse/NR-560142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ