### PR TITLE
fix: resolve CodeQL go/insecure-hostkeycallback in SCP

### DIFF
--- a/internal/inputs/scp.go
+++ b/internal/inputs/scp.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/newrelic/nri-flex/internal/utils"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // RunScpWithTimeout performs scp with timeout to gather data from a remote file.
@@ -68,14 +71,19 @@ func getSSHConnection(yml *load.Config, api load.API) (*sftp.Client, error) {
 		return nil, err
 	}
 
+	hostKeyCallback, err := getHostKeyCallback(api.Scp)
+	if err != nil {
+		return nil, fmt.Errorf("ssh: failed to set up host key verification: %v", err)
+	}
+
 	sshConfig := &ssh.ClientConfig{
 		User:            user,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         timeout,
 		Auth: []ssh.AuthMethod{
 			authMethod,
 		},
-	} // #nosec
+	}
 
 	sshConfig.SetDefaults()
 
@@ -90,6 +98,44 @@ func getSSHConnection(yml *load.Config, api load.API) (*sftp.Client, error) {
 		return nil, fmt.Errorf("ssh: failed to init sftp client, error: %v", err)
 	}
 	return client, nil
+}
+
+func getHostKeyCallback(scp load.SCP) (ssh.HostKeyCallback, error) {
+	knownHostsFile := expandHome(scp.KnownHostsFile)
+	if knownHostsFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine home directory: %v", err)
+		}
+		knownHostsFile = filepath.Join(home, ".ssh", "known_hosts")
+	}
+
+	if _, err := os.Stat(knownHostsFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("known_hosts file not found at %s. Create the file with "+
+			"'ssh-keyscan <host> >> %s', or specify a custom path with 'known_hosts_file'",
+			knownHostsFile, knownHostsFile)
+	}
+
+	callback, err := knownhosts.New(knownHostsFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read known_hosts file %s: %v", knownHostsFile, err)
+	}
+	return callback, nil
+}
+
+// expandHome replaces a leading ~ with the user's home directory.
+func expandHome(path string) string {
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
 }
 
 func getAuthMethod(yml *load.Config, api load.API) (ssh.AuthMethod, error) {

--- a/internal/inputs/scp_test.go
+++ b/internal/inputs/scp_test.go
@@ -6,11 +6,97 @@
 package inputs
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/newrelic/nri-flex/internal/load"
 )
+
+func TestGetHostKeyCallback_MissingKnownHostsFile(t *testing.T) {
+	scp := load.SCP{KnownHostsFile: "/nonexistent/path/known_hosts"}
+	_, err := getHostKeyCallback(scp)
+	if err == nil {
+		t.Fatal("expected error for missing known_hosts file")
+	}
+	if !strings.Contains(err.Error(), "known_hosts file not found") {
+		t.Fatalf("expected 'known_hosts file not found' error, got: %v", err)
+	}
+}
+
+func TestGetHostKeyCallback_CustomKnownHostsFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "scp-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a valid (empty) known_hosts file
+	knownHostsPath := filepath.Join(tmpDir, "known_hosts")
+	if err := os.WriteFile(knownHostsPath, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	scp := load.SCP{KnownHostsFile: knownHostsPath}
+	callback, err := getHostKeyCallback(scp)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if callback == nil {
+		t.Fatal("expected non-nil callback")
+	}
+}
+
+func TestGetHostKeyCallback_DefaultPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	defaultPath := filepath.Join(home, ".ssh", "known_hosts")
+	scp := load.SCP{}
+
+	_, cbErr := getHostKeyCallback(scp)
+	if _, statErr := os.Stat(defaultPath); os.IsNotExist(statErr) {
+		// If default known_hosts doesn't exist, we expect an error
+		if cbErr == nil {
+			t.Fatal("expected error when default known_hosts doesn't exist")
+		}
+		if !strings.Contains(cbErr.Error(), "known_hosts file not found") {
+			t.Fatalf("expected 'known_hosts file not found' error, got: %v", cbErr)
+		}
+	} else {
+		// If it exists, callback should succeed
+		if cbErr != nil {
+			t.Fatalf("expected no error when default known_hosts exists, got: %v", cbErr)
+		}
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"~/foo/bar", filepath.Join(home, "foo/bar")},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		result := expandHome(tc.input)
+		if result != tc.expected {
+			t.Errorf("expandHome(%q) = %q, want %q", tc.input, result, tc.expected)
+		}
+	}
+}
 
 func TestPublicKeyFile(t *testing.T) {
 	load.Refresh()
@@ -97,6 +183,8 @@ func TestGetSSHConnection(t *testing.T) {
 			"no route to host",
 			"network is unreachable",
 			"failed to connect to sftp host",
+			"known_hosts file not found",
+			"host key verification",
 		}
 
 		errorMatched := false

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -498,13 +498,14 @@ type JMX struct {
 
 // SCP struct
 type SCP struct {
-	User       string `yaml:"user"`
-	Pass       string `yaml:"pass"`
-	Host       string `yaml:"host"`
-	Port       string `yaml:"port"`
-	RemoteFile string `yaml:"remote_file"`
-	Passphrase string `yaml:"pass_phrase"`
-	SSHPEMFile string `yaml:"ssh_pem_file"`
+	User           string `yaml:"user"`
+	Pass           string `yaml:"pass"`
+	Host           string `yaml:"host"`
+	Port           string `yaml:"port"`
+	RemoteFile     string `yaml:"remote_file"`
+	Passphrase     string `yaml:"pass_phrase"`
+	SSHPEMFile     string `yaml:"ssh_pem_file"`
+	KnownHostsFile string `yaml:"known_hosts_file"`
 }
 
 // HWSigner struct


### PR DESCRIPTION
## Summary
- Replace `ssh.InsecureIgnoreHostKey()` with proper known_hosts verification using `knownhosts.New`
- Added `known_hosts_file` config option to specify a custom known_hosts path (supports `~` expansion)
- Returns actionable error if known_hosts file is not found
- Resolves CodeQL alert `go/insecure-hostkeycallback` ([NR-560141](https://new-relic.atlassian.net/browse/NR-560141))

## Breaking change — no opt-out

This PR removes all insecure SSH host key handling. There is **no fallback** and **no opt-out option**:

- Every SCP target host **must** be present in a known_hosts file (default: `~/.ssh/known_hosts`)
- Users on dynamic/ephemeral infrastructure must provision known_hosts as part of their setup, e.g.:
  ```
  ssh-keyscan <target-host> >> ~/.ssh/known_hosts
  ```
- Alternatively, specify a custom file with the `known_hosts_file` config option

Users who previously relied on the insecure behavior will see connection errors until they add their target hosts to known_hosts.

## Test plan
- [x] Unit tests for `getHostKeyCallback` (missing file, custom path, default path)
- [x] Unit tests for `expandHome` (tilde expansion)
- [x] `go test ./internal/inputs/...` passes
- [ ] Smoke test against a real host in known_hosts to verify end-to-end connection
- [ ] Confirm CodeQL alert auto-closes after merge

[NR-560141]: https://new-relic.atlassian.net/browse/NR-560141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ