### PR TITLE
fix: resolve CodeQL go/weak-sensitive-data-hashing

### DIFF
--- a/internal/utils/simpleEncryt.go
+++ b/internal/utils/simpleEncryt.go
@@ -8,14 +8,14 @@ package utils
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/md5" // nolint
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"io"
 )
 
 func createHash(key string) string {
-	hasher := md5.New() // nolint
+	hasher := sha256.New()
 	hasher.Write([]byte(key))
 	return hex.EncodeToString(hasher.Sum(nil))
 }


### PR DESCRIPTION
## Summary
- Replace MD5 with SHA256 for key derivation in encrypt/decrypt functions
- Resolves CodeQL alert `go/weak-sensitive-data-hashing` ([NR-560139](https://new-relic.atlassian.net/browse/NR-560139))

## Breaking change
This changes the key derivation from MD5 (16 bytes / AES-128) to SHA256 (32 bytes / AES-256). Data encrypted with the previous version **cannot be decrypted** with this version.

## Test plan
- [ ] Verify CI passes
- [ ] Confirm CodeQL alert auto-closes after merge
- [ ] Assess if any persisted encrypted data exists that would be affected

[NR-560139]: https://new-relic.atlassian.net/browse/NR-560139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ