### PR TITLE
fix: remove unavailable packages from Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-# Use Ubuntu 16.04 as the base image
+# Use Ubuntu 26.04 as the base image
 FROM ubuntu:26.04
 
 # Define Go version
@@ -21,9 +21,7 @@ RUN apt-get update && apt-get install -y \
     rpm \
     build-essential \
     software-properties-common \
-    python-software-properties \
     gcc-arm-linux-gnueabi \
-    dpkg-sig \
     gcc-aarch64-linux-gnu
 
 # Install Go


### PR DESCRIPTION
## Summary
- Remove `python-software-properties` and `dpkg-sig` from `build/Dockerfile`
- These packages don't exist in Ubuntu 26.04 (they were from the 16.04 era)
- Fixes CI build failures introduced by #633 (Ubuntu 16.04 → 26.04 upgrade)

## Test plan
- [ ] Verify Docker-based CI jobs (unit tests, integration tests, binary compilation) pass