### PR TITLE
fix: race condition for async db queries

### DIFF
--- a/internal/inputs/database.go
+++ b/internal/inputs/database.go
@@ -97,11 +97,16 @@ func ProcessQueries(dataStore *[]interface{}, yml *load.Config, apiNo int) {
 	// execute queries async else do synchronously
 	if api.DBAsync {
 		var wg sync.WaitGroup
+		var mu sync.Mutex
 		wg.Add(len(api.DBQueries))
 		for _, query := range api.DBQueries {
 			go func(query load.Command) {
 				defer wg.Done()
-				checkAndRunQuery(db, query, api, yml, dataStore)
+				localStore := []interface{}{}
+				checkAndRunQuery(db, query, api, yml, &localStore)
+				mu.Lock()
+				*dataStore = append(*dataStore, localStore...)
+				mu.Unlock()
 			}(query)
 		}
 		wg.Wait()


### PR DESCRIPTION
<details>

<summary>Problem</summary>

```
❯ go run -race ./cmd/nri-flex/ -config_path ./rohan_work/test-configs/mssql-async-test.yml -pretty

INFO[0000] com.newrelic.nri-flex                         GOARCH=arm64 GOOS=darwin version=Unknown-SNAPSHOT
==================
WARNING: DATA RACE
Read at 0x00c0000137a0 by goroutine 34:
  github.com/newrelic/nri-flex/internal/inputs.runQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:202 +0xd40
  github.com/newrelic/nri-flex/internal/inputs.checkAndRunQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:124 +0x334
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:104 +0x184
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.gowrap2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:105 +0xa0

Previous write at 0x00c0000137a0 by goroutine 33:
  github.com/newrelic/nri-flex/internal/inputs.runQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:202 +0xdd0
  github.com/newrelic/nri-flex/internal/inputs.checkAndRunQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:124 +0x334
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:104 +0x184
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.gowrap2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:105 +0xa0

Goroutine 34 (running) created at:
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:102 +0xc88
  github.com/newrelic/nri-flex/internal/config.FetchData()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/fetch.go:59 +0x30c
  github.com/newrelic/nri-flex/internal/config.Run()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:221 +0x2fc
  github.com/newrelic/nri-flex/internal/config.RunFiles.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:344 +0x21c
  github.com/newrelic/nri-flex/internal/config.RunFiles.gowrap1()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:347 +0x90

Goroutine 33 (finished) created at:
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:102 +0xc88
  github.com/newrelic/nri-flex/internal/config.FetchData()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/fetch.go:59 +0x30c
  github.com/newrelic/nri-flex/internal/config.Run()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:221 +0x2fc
  github.com/newrelic/nri-flex/internal/config.RunFiles.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:344 +0x21c
  github.com/newrelic/nri-flex/internal/config.RunFiles.gowrap1()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:347 +0x90
==================
==================
WARNING: DATA RACE
Read at 0x00c0009a8150 by goroutine 34:
  runtime.growslice()
      /Users/rohanyadav/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/runtime/slice.go:178 +0x0
  github.com/newrelic/nri-flex/internal/inputs.runQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:202 +0xd70
  github.com/newrelic/nri-flex/internal/inputs.checkAndRunQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:124 +0x334
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:104 +0x184
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.gowrap2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:105 +0xa0

Previous write at 0x00c0009a8150 by goroutine 33:
  github.com/newrelic/nri-flex/internal/inputs.runQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:202 +0xd90
  github.com/newrelic/nri-flex/internal/inputs.checkAndRunQuery()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:124 +0x334
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:104 +0x184
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries.gowrap2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:105 +0xa0

Goroutine 34 (running) created at:
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:102 +0xc88
  github.com/newrelic/nri-flex/internal/config.FetchData()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/fetch.go:59 +0x30c
  github.com/newrelic/nri-flex/internal/config.Run()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:221 +0x2fc
  github.com/newrelic/nri-flex/internal/config.RunFiles.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:344 +0x21c
  github.com/newrelic/nri-flex/internal/config.RunFiles.gowrap1()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:347 +0x90

Goroutine 33 (finished) created at:
  github.com/newrelic/nri-flex/internal/inputs.ProcessQueries()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/inputs/database.go:102 +0xc88
  github.com/newrelic/nri-flex/internal/config.FetchData()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/fetch.go:59 +0x30c
  github.com/newrelic/nri-flex/internal/config.Run()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:221 +0x2fc
  github.com/newrelic/nri-flex/internal/config.RunFiles.func2()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:344 +0x21c
  github.com/newrelic/nri-flex/internal/config.RunFiles.gowrap1()
      /Users/rohanyadav/Documents/nr/nri/nri-flex/internal/config/config.go:347 +0x90
==================
INFO[0000] flex: completed processing configs            configs=1
{
        "name": "com.newrelic.nri-flex",
        "protocol_version": "3",
        "integration_version": "Unknown-SNAPSHOT",
        "data": [
                {
                        "metrics": [
                                {
                                        "event_type": "fast3",
                                        "flex.QueryStartMs": 1782291411946,
                                        "flex.QueryTimeMs": 2,
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "Unknown-SNAPSHOT",
                                        "queryLabel": "fast3",
                                        "rowIdentifier": "fast3_1",
                                        "val": 3
                                },
                                {
                                        "event_type": "fast1",
                                        "flex.QueryStartMs": 1782291411946,
                                        "flex.QueryTimeMs": 20,
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "Unknown-SNAPSHOT",
                                        "queryLabel": "fast1",
                                        "rowIdentifier": "fast1_1",
                                        "val": 1
                                },
                                {
                                        "event_type": "fast2",
                                        "flex.QueryStartMs": 1782291411946,
                                        "flex.QueryTimeMs": 20,
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "Unknown-SNAPSHOT",
                                        "queryLabel": "fast2",
                                        "rowIdentifier": "fast2_1",
                                        "val": 2
                                },
                                {
                                        "event_type": "flexStatusSample",
                                        "flex.Hostname": "C3JKHGMYPX",
                                        "flex.IntegrationVersion": "Unknown-SNAPSHOT",
                                        "flex.counter.ConfigsProcessed": 1,
                                        "flex.counter.EventCount": 3,
                                        "flex.counter.EventDropCount": 0,
                                        "flex.counter.fast1": 1,
                                        "flex.counter.fast2": 1,
                                        "flex.counter.fast3": 1,
                                        "flex.time.elapsedMs": 89,
                                        "flex.time.endMs": 1782291411970,
                                        "flex.time.startMs": 1782291411881
                                }
                        ],
                        "inventory": {},
                        "events": []
                }
        ]
}
Found 2 data race(s)
exit status 66
```

</details>

<details>

<summary>After fix</summary>

```
❯ go run -race ./cmd/nri-flex/ -config_path ./rohan_work/test-configs/mssql-async-test.yml -pretty

INFO[0000] com.newrelic.nri-flex                         GOARCH=arm64 GOOS=darwin version=Unknown-SNAPSHOT
INFO[0000] flex: completed processing configs            configs=1
{
        "name": "com.newrelic.nri-flex",
        "protocol_version": "3",
        "integration_version": "Unknown-SNAPSHOT",
        "data": [
                {
                        "metrics": [
                                {
                                        "event_type": "fast3",
                                        "flex.QueryStartMs": 1782297998049,
                                        "flex.QueryTimeMs": 1,
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "Unknown-SNAPSHOT",
                                        "queryLabel": "fast3",
                                        "rowIdentifier": "fast3_1",
                                        "val": 3
                                },
                                {
                                        "event_type": "fast1",
                                        "flex.QueryStartMs": 1782297998049,
                                        "flex.QueryTimeMs": 25,
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "Unknown-SNAPSHOT",
                                        "queryLabel": "fast1",
                                        "rowIdentifier": "fast1_1",
                                        "val": 1
                                },
                                {
                                        "event_type": "fast2",
                                        "flex.QueryStartMs": 1782297998049,
                                        "flex.QueryTimeMs": 26,
                                        "integration_name": "com.newrelic.nri-flex",
                                        "integration_version": "Unknown-SNAPSHOT",
                                        "queryLabel": "fast2",
                                        "rowIdentifier": "fast2_1",
                                        "val": 2
                                },
                                {
                                        "event_type": "flexStatusSample",
                                        "flex.Hostname": "C3JKHGMYPX",
                                        "flex.IntegrationVersion": "Unknown-SNAPSHOT",
                                        "flex.counter.ConfigsProcessed": 1,
                                        "flex.counter.EventCount": 3,
                                        "flex.counter.EventDropCount": 0,
                                        "flex.counter.fast1": 1,
                                        "flex.counter.fast2": 1,
                                        "flex.counter.fast3": 1,
                                        "flex.time.elapsedMs": 84,
                                        "flex.time.endMs": 1782297998076,
                                        "flex.time.startMs": 1782297997992
                                }
                        ],
                        "inventory": {},
                        "events": []
                }
        ]
}
```

</details>