### PR TITLE
fix: close rows in runQuery to prevent connection pool leak under db_async

### DIFF
--- a/internal/inputs/database.go
+++ b/internal/inputs/database.go
@@ -142,6 +142,7 @@ func runQuery(db *sql.DB, query load.Command, api load.API, yml *load.Config, da
 		errorLogToInsights(err, api.Database, api.Name, query.Name)
 		return
 	}
+	defer rows.Close()
 
 	load.Logrus.WithFields(logrus.Fields{
 		"configName": yml.Name,


### PR DESCRIPTION
## What
`runQuery` in `internal/inputs/database.go` never calls `rows.Close()`. The `rows.Columns()` and `rows.Scan()` error paths return early without closing, which leaks that connection's slot in the pool for the rest of the process's life (`db.Close()` only reaps idle connections, not ones still marked in-use — and `*sql.Rows` has no finalizer to clean this up for you). Adds a single `defer rows.Close()` right after the successful `db.Query()`.