### PR TITLE
feat: add pipeline to register released versions to agent-control catalog and agent-type files

### DIFF
--- a/.fleetControl/agentControl/linux.yml
+++ b/.fleetControl/agentControl/linux.yml
@@ -1,0 +1,75 @@
+namespace: newrelic
+name: com.newrelic.infrastructure.nri_flex
+version: 0.1.0
+platform: host
+operating_system: linux
+protocol_version: "1.0"
+variables:
+  config:
+    description: "nri-flex integration YAML consumed by the infra-agent"
+    type: yaml
+    required: true
+  version:
+    description: "Agent version"
+    type: string
+    required: true
+  files:
+    description: "nri-flex additional files that can be references from configuration"
+    type: string_map
+    required: false
+    default: {}
+  oci:
+    repository:
+      description: "OCI repository name for nri-flex"
+      type: string
+      required: false
+      default: newrelic/nri-flex-artifacts
+      variants:
+        ac_config_field: "oci_repository_urls"
+        values: [ "newrelic/nri-flex-artifacts" ]
+deployment:
+  packages:
+    nri-flex:
+      download:
+        oci:
+          repository: ${nr-var:oci.repository}
+          version: ${nr-var:version}
+          public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nri-flex/jwks.json
+  # Allows setting up additional files to be referenced from nri-flex configuration.
+  # Example in values:
+  #
+  # ```
+  # files:
+  #   my_script.sh: |
+  #     <SCRIPT-CONTENT>
+  #
+  # config:
+  #   integrations:
+  #     - name: nri-flex
+  #       interval: 60s
+  #       config:
+  #         name: my-flex
+  #         apis:
+  #           - event_type: CustomEvent
+  #             commands:
+  #               - run: bash ${nr-path:agent_dir}/files/my_script.sh
+  # ```
+  filesystem:
+    files:
+      kind: dir_content_from_map
+      source: ${nr-var:files}
+
+  shared_filesystem:
+    infra-agent-ohi-configs:
+      kind: dir
+      entries:
+        nri-flex.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
+    infra-agent-ohi-binaries:
+      kind: dir
+      entries:
+        nri-flex:
+          kind: file
+          copy_from_file: ${nr-sub:packages.nri-flex.dir}/nri-flex

--- a/.fleetControl/agentControl/windows.yml
+++ b/.fleetControl/agentControl/windows.yml
@@ -1,0 +1,77 @@
+namespace: newrelic
+name: com.newrelic.infrastructure.nri_flex
+version: 0.1.0
+platform: host
+operating_system: windows
+protocol_version: "1.0"
+variables:
+  config:
+    description: "nri-flex integration YAML consumed by the infra-agent"
+    type: yaml
+    required: true
+  version:
+    description: "Agent version"
+    type: string
+    required: true
+  files:
+    description: "nri-flex additional files that can be references from configuration"
+    type: string_map
+    required: false
+    default: {}
+  oci:
+    repository:
+      description: "OCI repository name for nri-flex"
+      type: string
+      required: false
+      default: newrelic/nri-flex-artifacts
+      variants:
+        ac_config_field: "oci_repository_urls"
+        values: [ "newrelic/nri-flex-artifacts" ]
+deployment:
+  packages:
+    nri-flex:
+      download:
+        oci:
+          repository: ${nr-var:oci.repository}
+          version: ${nr-var:version}
+          public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nri-flex/jwks.json
+  # Allows setting up additional files to be referenced from nri-flex configuration.
+  # Example in values:
+  #
+  # ```
+  # files:
+  #   my_script.ps1: |
+  #     <SCRIPT-CONTENT>
+  #
+  # config:
+  #   integrations:
+  #     - name: nri-flex
+  #       interval: 60s
+  #       config:
+  #         name: my-flex
+  #         apis:
+  #           - event_type: CustomEvent
+  #             shell: powershell
+  #             commands:
+  #               # The agent dir can contain spaces (e.g. "New Relic"), so quote the path and
+  #               # use the call operator "&" rather than referencing it as a bare command.
+  #               - run: '& "${nr-path:agent_dir}\files\my_script.ps1"'
+  # ```
+  filesystem:
+    files:
+      kind: dir_content_from_map
+      source: ${nr-var:files}
+  shared_filesystem:
+    infra-agent-ohi-configs:
+      kind: dir
+      entries:
+        nri-flex.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
+    infra-agent-ohi-binaries:
+      kind: dir
+      entries:
+        nri-flex.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.nri-flex.dir}\\nri-flex.exe

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,0 +1,11 @@
+agentControlDefinitions:
+  - platform: HOST
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.19.0
+    content: ./agentControl/windows.yml
+    operatingSystem: WINDOWS
+  - platform: HOST
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.19.0
+    content: ./agentControl/linux.yml
+    operatingSystem: LINUX

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,11 +1,11 @@
 agentControlDefinitions:
   - platform: HOST
     supportFromAgent: 1.0.0
-    supportFromAgentControl: 1.19.0
+    supportFromAgentControl: 1.21.0
     content: ./agentControl/windows.yml
     operatingSystem: WINDOWS
   - platform: HOST
     supportFromAgent: 1.0.0
-    supportFromAgentControl: 1.19.0
+    supportFromAgentControl: 1.21.0
     content: ./agentControl/linux.yml
     operatingSystem: LINUX

--- a/.fleetControl/agentDefinition.yml
+++ b/.fleetControl/agentDefinition.yml
@@ -1,0 +1,15 @@
+bindings:
+  - type: REQUIRES
+    targetType: AGENT
+    target: NRInfra
+    platform: HOST
+    operatingSystem: LINUX
+    versions:
+      - ">1.71.0"
+  - type: REQUIRES
+    targetType: AGENT
+    target: NRInfra
+    platform: HOST
+    operatingSystem: WINDOWS
+    versions:
+      - ">1.71.0"

--- a/.fleetControl/configurationDefinitions.yml
+++ b/.fleetControl/configurationDefinitions.yml
@@ -1,0 +1,13 @@
+configurationDefinitions:
+  - platform: HOST
+    description: flex integration configuration
+    type: agent-config
+    version: 1.0.0
+    format: yml
+    operatingSystem: LINUX
+  - platform: HOST
+    description: flex integration configuration
+    type: agent-config
+    version: 1.0.0
+    format: yml
+    operatingSystem: WINDOWS

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -23,6 +23,8 @@ jobs:
       display_name: "Flex"
       monitoring_type: "INFRA"
       oci_registry: "docker.io/newrelic/nri-flex-artifacts"
+      source_repo: "newrelic/nri-flex"
+      metadata_git_ref: "master"
       artifacts: |
         [
           {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-flex_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["nri-flex"]},

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -1,0 +1,37 @@
+name: Publish agent to catalog
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to process (e.g., v1.18.10)'
+        required: true
+        type: string
+  release:
+    types:
+      - released
+
+permissions:
+  contents: read
+
+jobs:
+  oci-publish:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@v3
+    with:
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+      agent_type: NRIFlex
+      display_name: "Flex"
+      monitoring_type: "INFRA"
+      oci_registry: "docker.io/newrelic/nri-flex-artifacts"
+      artifacts: |
+        [
+          {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-flex_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["nri-flex"]},
+          {"name":"linux-arm64","os":"linux","arch":"arm64","format":"tar+gzip","source_asset":"nri-flex_linux_{version}_arm64.tar.gz","source_format":"tar.gz","keep_files":["nri-flex"]},
+          {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-flex_windows_{version}_amd64.zip","source_format":"zip","keep_files":["nri-flex.exe"]}
+        ]
+    secrets:
+      OHAI_NEWRELIC_CLIENT_ID: ${{ secrets.OHAI_NEWRELIC_CLIENT_ID }}
+      OHAI_NEWRELIC_PRIVATE_KEY: ${{ secrets.OHAI_NEWRELIC_PRIVATE_KEY }}
+      OHAI_OCI_USERNAME: ${{ secrets.OHAI_OCI_USERNAME }}
+      OHAI_OCI_PASSWORD: ${{ secrets.OHAI_OCI_PASSWORD }}
+      OHAI_APM_CONTROL_NR_LICENSE_KEY_STAGING: ${{ secrets.OHAI_APM_CONTROL_NR_LICENSE_KEY_STAGING }}

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -23,8 +23,6 @@ jobs:
       display_name: "Flex"
       monitoring_type: "INFRA"
       oci_registry: "docker.io/newrelic/nri-flex-artifacts"
-      source_repo: "newrelic/nri-flex"
-      metadata_git_ref: "master"
       artifacts: |
         [
           {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-flex_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["nri-flex"]},


### PR DESCRIPTION
## Why
Integrated nri-flex into the catalog used for newrelic-control.

## What
1. Add a pipeline that uploads the binaries to an oci repository, and signs it
2. Add to the catalog the latest version and the agent-type (`linux.yml` and `windows.yml`)

## Please note
1. Pipeline has already been run for the latest nri-flex version, validating it works and registering that version within the supported agent-control catalog.